### PR TITLE
ClassInjector Support for Returning Structs

### DIFF
--- a/UnhollowerBaseLib/ClassInjector.cs
+++ b/UnhollowerBaseLib/ClassInjector.cs
@@ -658,16 +658,23 @@ namespace UnhollowerRuntimeLib
             {
                 if (monoMethod.ReturnType.IsValueType)
                 {
-                    if (monoMethod.ReturnType == typeof(long) || monoMethod.ReturnType == typeof(ulong))
-                    {
-                        body.Emit(OpCodes.Ldc_I4_0);
-                        body.Emit(OpCodes.Conv_I8);
+                    if(monoMethod.ReturnType.IsPrimitive)
+                    { 
+                        if(monoMethod.ReturnType == typeof(float))
+                            body.Emit(OpCodes.Ldc_R4, 0);
+                        else if (monoMethod.ReturnType == typeof(double))
+                            body.Emit(OpCodes.Ldc_R8, 0);
+                        else
+                        {
+                            body.Emit(OpCodes.Ldc_I4_0);
+                            if(monoMethod.ReturnType == typeof(long) || monoMethod.ReturnType == typeof(ulong))
+                            {
+                                body.Emit(OpCodes.Conv_I8);
+                            }
+                        }
                     }
-                    else if (monoMethod.ReturnType == typeof(float))
-                        body.Emit(OpCodes.Ldc_R4, 0);
-                    else if (monoMethod.ReturnType == typeof(double))
-                        body.Emit(OpCodes.Ldc_R8, 0);
-                    else {
+                    else
+                    {
                         var local = body.DeclareLocal(monoMethod.ReturnType);
 
                         body.Emit(OpCodes.Ldloca_S, local);


### PR DESCRIPTION
Adds support for returning structs in `CreateTrampoline`

Unsure if this causes issues with other ValueTypes that aren't struct as I have only done testing on GTFO (Unity 2019.4.21)