### PR TITLE
Prefix Almost Everything

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -352,3 +352,5 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+launchsettings.json

--- a/Il2CppInterop.CLI/Program.cs
+++ b/Il2CppInterop.CLI/Program.cs
@@ -19,8 +19,8 @@ var generateCommand = new Command("generate")
     new Option<DirectoryInfo>("--unity", "Directory with original Unity assemblies for unstripping").ExistingOnly(),
     new Option<FileInfo>("--game-assembly", "Path to GameAssembly.dll. Used for certain analyses").ExistingOnly(),
     new Option<bool>("--no-xref-cache", "Don't generate xref scanning cache. All scanning will be done at runtime."),
-    new Option<string[]>("--add-prefix-to",
-        "Assemblies and namespaces starting with these will get an Il2Cpp prefix in generated assemblies. Allows multiple values."),
+    new Option<string[]>("--dont-add-prefix-to",
+        "Assemblies and namespaces starting with these will not get an Il2Cpp prefix in generated assemblies. Allows multiple values."),
     new Option<FileInfo>("--deobf-map",
         "Specifies a file specifying deobfuscation map for obfuscated types and members.").ExistingOnly(),
     new Option<int>("--deobf-uniq-chars", "How many characters per unique token to use during deobfuscation"),
@@ -47,8 +47,8 @@ deobfCommand.Description = "Tools for deobfuscating assemblies";
 var deobfAnalyzeCommand = new Command("analyze")
 {
     new Option<DirectoryInfo>("--input", "Directory of assemblies to deobfuscate") {IsRequired = true}.ExistingOnly(),
-    new Option<string[]>("--add-prefix-to",
-        "Assemblies and namespaces starting with these will get an Il2Cpp prefix in generated assemblies. Allows multiple values.")
+    new Option<string[]>("--dont-add-prefix-to",
+        "Assemblies and namespaces starting with these will not get an Il2Cpp prefix in generated assemblies. Allows multiple values.")
 };
 deobfAnalyzeCommand.Description =
     "Analyze deobfuscation performance with different parameter values. Will not generate assemblies.";
@@ -152,7 +152,7 @@ internal record GenerateCommandOptions(
     DirectoryInfo? Unity,
     FileInfo? GameAssembly,
     bool NoXrefCache,
-    string[]? AddPrefixTo,
+    string[]? DontAddPrefixTo,
     FileInfo? DeobfMap,
     int DeobfUniqChars,
     int DeobfUniqMax,
@@ -179,11 +179,11 @@ internal record GenerateCommandOptions(
         opts.PassthroughNames = PassthroughNames;
         opts.Parallel = !NoParallel;
 
-        if (AddPrefixTo is not null)
+        if (DontAddPrefixTo is not null)
         {
-            foreach (var s in AddPrefixTo)
+            foreach (var s in DontAddPrefixTo)
             {
-                opts.NamespacesAndAssembliesToPrefix.Add(s);
+                opts.NamespacesAndAssembliesToNotPrefix.Add(s);
             }
         }
 
@@ -198,7 +198,7 @@ internal record GenerateCommandOptions(
 
 internal record DeobfAnalyzeCommandOptions(
     bool Verbose,
-    string[]? AddPrefixTo,
+    string[]? DontAddPrefixTo,
     DirectoryInfo Input
 ) : BaseCmdOptions(Verbose)
 {
@@ -208,11 +208,11 @@ internal record DeobfAnalyzeCommandOptions(
         var opts = res.Options;
 
         opts.Source = Utils.LoadAssembliesFrom(Input);
-        if (AddPrefixTo is not null)
+        if (DontAddPrefixTo is not null)
         {
-            foreach (var s in AddPrefixTo)
+            foreach (var s in DontAddPrefixTo)
             {
-                opts.NamespacesAndAssembliesToPrefix.Add(s);
+                opts.NamespacesAndAssembliesToNotPrefix.Add(s);
             }
         }
 

--- a/Il2CppInterop.CLI/Program.cs
+++ b/Il2CppInterop.CLI/Program.cs
@@ -24,7 +24,7 @@ var generateCommand = new Command("generate")
     new Option<string[]>("--dont-add-prefix-to",
         "Assemblies and namespaces starting with these will not get an Il2Cpp prefix in generated assemblies. Allows multiple values."),
     new Option<bool>("--use-opt-out-prefixing",
-        "Assemblies and namespaces starting with will get an Il2Cpp prefix in generated assemblies unless otherwise specified. Obsolete."),
+        "Assemblies and namespaces will get an Il2Cpp prefix in generated assemblies unless otherwise specified. Obsolete."),
     new Option<FileInfo>("--deobf-map",
         "Specifies a file specifying deobfuscation map for obfuscated types and members.").ExistingOnly(),
     new Option<int>("--deobf-uniq-chars", "How many characters per unique token to use during deobfuscation"),
@@ -56,7 +56,7 @@ var deobfAnalyzeCommand = new Command("analyze")
     new Option<string[]>("--dont-add-prefix-to",
         "Assemblies and namespaces starting with these will not get an Il2Cpp prefix in generated assemblies. Allows multiple values."),
     new Option<bool>("--use-opt-out-prefixing",
-        "Assemblies and namespaces starting with will get an Il2Cpp prefix in generated assemblies unless otherwise specified. Obsolete.")
+        "Assemblies and namespaces will get an Il2Cpp prefix in generated assemblies unless otherwise specified. Obsolete.")
 };
 deobfAnalyzeCommand.Description =
     "Analyze deobfuscation performance with different parameter values. Will not generate assemblies.";

--- a/Il2CppInterop.Generator/Extensions/StringEx.cs
+++ b/Il2CppInterop.Generator/Extensions/StringEx.cs
@@ -7,11 +7,11 @@ public static class StringEx
 {
     public static string UnSystemify(this string str, GeneratorOptions options)
     {
-        foreach (var prefix in options.NamespacesAndAssembliesToPrefix)
-            if (str.StartsWith(prefix))
-                return "Il2Cpp" + str;
+        foreach (var prefix in options.NamespacesAndAssembliesToNotPrefix)
+            if (str.StartsWith(prefix, StringComparison.Ordinal))
+                return str;
 
-        return str;
+        return $"Il2Cpp{str}";
     }
 
     public static string FilterInvalidInSourceChars(this string str)

--- a/Il2CppInterop.Generator/Extensions/StringEx.cs
+++ b/Il2CppInterop.Generator/Extensions/StringEx.cs
@@ -7,11 +7,23 @@ public static class StringEx
 {
     public static string UnSystemify(this string str, GeneratorOptions options)
     {
-        foreach (var prefix in options.NamespacesAndAssembliesToNotPrefix)
-            if (str.StartsWith(prefix, StringComparison.Ordinal))
-                return str;
+        const string Il2CppPrefix = "Il2Cpp";
+        if (options.Il2CppPrefixMode == GeneratorOptions.PrefixMode.OptIn)
+        {
+            foreach (var prefix in options.NamespacesAndAssembliesToPrefix)
+                if (str.StartsWith(prefix, StringComparison.Ordinal))
+                    return Il2CppPrefix + str;
 
-        return $"Il2Cpp{str}";
+            return str;
+        }
+        else
+        {
+            foreach (var prefix in options.NamespacesAndAssembliesToNotPrefix)
+                if (str.StartsWith(prefix, StringComparison.Ordinal))
+                    return str;
+
+            return Il2CppPrefix + str;
+        }
     }
 
     public static string FilterInvalidInSourceChars(this string str)

--- a/Il2CppInterop.Generator/GeneratorOptions.cs
+++ b/Il2CppInterop.Generator/GeneratorOptions.cs
@@ -22,8 +22,11 @@ public class GeneratorOptions
     public bool PassthroughNames { get; set; }
     public bool Parallel { get; set; } = true;
 
+    public PrefixMode Il2CppPrefixMode { get; set; } = PrefixMode.OptIn;
+    public HashSet<string> NamespacesAndAssembliesToPrefix { get; } =
+        new() { "System", "mscorlib", "Microsoft", "Mono", "I18N" };
     public HashSet<string> NamespacesAndAssembliesToNotPrefix { get; } =
-        new() { "UnityEditor", "UnityEngine" };
+        new() { "Unity" };
 
     public List<string> DeobfuscationGenerationAssemblies { get; } = new();
     public string? DeobfuscationNewAssembliesPath { get; set; }
@@ -59,5 +62,17 @@ public class GeneratorOptions
             if (split.Length < 2) continue;
             RenameMap[split[0]] = split[1];
         }
+    }
+
+    public enum PrefixMode
+    {
+        /// <summary>
+        ///     Only specified namespaces and assemblies will be renamed.
+        /// </summary>
+        OptIn,
+        /// <summary>
+        ///     Only specified namespaces and assemblies will not be renamed.
+        /// </summary>
+        OptOut
     }
 }

--- a/Il2CppInterop.Generator/GeneratorOptions.cs
+++ b/Il2CppInterop.Generator/GeneratorOptions.cs
@@ -22,8 +22,8 @@ public class GeneratorOptions
     public bool PassthroughNames { get; set; }
     public bool Parallel { get; set; } = true;
 
-    public HashSet<string> NamespacesAndAssembliesToPrefix { get; } =
-        new() { "System", "mscorlib", "Microsoft", "Mono", "I18N" };
+    public HashSet<string> NamespacesAndAssembliesToNotPrefix { get; } =
+        new() { "UnityEditor", "UnityEngine" };
 
     public List<string> DeobfuscationGenerationAssemblies { get; } = new();
     public string? DeobfuscationNewAssembliesPath { get; set; }

--- a/Il2CppInterop.Generator/GeneratorOptions.cs
+++ b/Il2CppInterop.Generator/GeneratorOptions.cs
@@ -26,7 +26,7 @@ public class GeneratorOptions
     public HashSet<string> NamespacesAndAssembliesToPrefix { get; } =
         new() { "System", "mscorlib", "Microsoft", "Mono", "I18N" };
     public HashSet<string> NamespacesAndAssembliesToNotPrefix { get; } =
-        new() { "Unity" };
+        new() { "Assembly-CSharp", "Unity" };
 
     public List<string> DeobfuscationGenerationAssemblies { get; } = new();
     public string? DeobfuscationNewAssembliesPath { get; set; }

--- a/Il2CppInterop.Generator/Il2CppInterop.Generator.csproj
+++ b/Il2CppInterop.Generator/Il2CppInterop.Generator.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IsExternalInit" Version="1.0.2">
+    <PackageReference Include="IsExternalInit" Version="1.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Game developers often use the global namespace and external libraries when making their games. For modding, this can cause conflicts during mod development. Although we currently have a way to prefix assemblies and namespaces, it's an opt-in system. An opt-out solution would be better because mod loaders can't anticipate all the assemblies game communities might want to prefix. By prefixing everything but UnityEditor and UnityEngine, we can prevent all potential conflicts between generated interop and managed libraries.