### PR TITLE
Merge ConvertManagedTypeToIL2CPPType and NativeType

### DIFF
--- a/Il2CppInterop.Runtime/Il2CppInterop.Runtime.csproj
+++ b/Il2CppInterop.Runtime/Il2CppInterop.Runtime.csproj
@@ -11,6 +11,12 @@
     <Platforms>AnyCPU</Platforms>
     <ImplicitUsings>false</ImplicitUsings>
   </PropertyGroup>
+  
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>Il2CppInterop.HarmonySupport</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
 
   <ItemGroup>
     <Reference Include="Il2Cppmscorlib">

--- a/Il2CppInterop.Runtime/Injection/ClassInjector.cs
+++ b/Il2CppInterop.Runtime/Injection/ClassInjector.cs
@@ -952,11 +952,6 @@ public static unsafe class ClassInjector
         return builder.ToString();
     }
 
-    internal static Type NativeType(this Type type)
-    {
-        return type.IsValueType ? type : typeof(IntPtr);
-    }
-
     private static Type RewriteType(Type type)
     {
         if (type.IsValueType && !type.IsEnum)

--- a/Il2CppInterop.Runtime/Injection/TrampolineHelpers.cs
+++ b/Il2CppInterop.Runtime/Injection/TrampolineHelpers.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+using Il2CppInterop.Runtime.InteropTypes;
+
+namespace Il2CppInterop.Runtime.Injection;
+
+internal static class TrampolineHelpers
+{
+    private static AssemblyBuilder _fixedStructAssembly;
+    private static ModuleBuilder _fixedStructModuleBuilder;
+    private static readonly Dictionary<int, Type> _fixedStructCache = new();
+
+    private static Type GetFixedSizeStructType(int size)
+    {
+        if (_fixedStructCache.TryGetValue(size, out var result))
+        {
+            return result;
+        }
+
+        _fixedStructAssembly ??= AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("FixedSizeStructAssembly"), AssemblyBuilderAccess.Run);
+        _fixedStructModuleBuilder ??= _fixedStructAssembly.DefineDynamicModule("FixedSizeStructAssembly");
+
+        var tb = _fixedStructModuleBuilder.DefineType($"IL2CPPDetour_FixedSizeStruct_{size}b", TypeAttributes.ExplicitLayout, typeof(ValueType), size);
+
+        var type = tb.CreateType();
+        return _fixedStructCache[size] = type;
+    }
+
+    internal static Type NativeType(this Type managedType)
+    {
+        if (managedType.IsByRef)
+        {
+            var directType = managedType.GetElementType();
+
+            // bool is byte in Il2Cpp, but int in CLR => force size to be correct
+            if (directType == typeof(bool))
+            {
+                return typeof(byte).MakeByRefType();
+            }
+
+            if (directType == typeof(string) || directType.IsSubclassOf(typeof(Il2CppObjectBase)))
+            {
+                return typeof(IntPtr*);
+            }
+        }
+        else if (managedType.IsSubclassOf(typeof(Il2CppSystem.ValueType)) && !Environment.Is64BitProcess)
+        {
+            // Struct that's passed on the stack => handle as general struct
+            uint align = 0;
+            var fixedSize = IL2CPP.il2cpp_class_value_size(Il2CppClassPointerStore.GetNativeClassPointer(managedType), ref align);
+            return GetFixedSizeStructType(fixedSize);
+        }
+        else if (managedType == typeof(string) || managedType.IsSubclassOf(typeof(Il2CppObjectBase))) // General reference type
+        {
+            return typeof(IntPtr);
+        }
+        else if (managedType == typeof(bool))
+        {
+            // bool is byte in Il2Cpp, but int in CLR => force size to be correct
+            return typeof(byte);
+        }
+
+        return managedType;
+    }
+}


### PR DESCRIPTION
Currently HarmonySupport and ClassInjector do the same thing but differently leading to issues on x32. This PR fixes injecting methods that use structs on 32 bit.