### PR TITLE
Don't generate interop methods for interface overrides

### DIFF
--- a/Il2CppInterop.Generator/Contexts/TypeRewriteContext.cs
+++ b/Il2CppInterop.Generator/Contexts/TypeRewriteContext.cs
@@ -99,6 +99,7 @@ public class TypeRewriteContext
             if (originalTypeMethod.Name == ".cctor") continue;
             if (originalTypeMethod.Name == ".ctor" && originalTypeMethod.Parameters.Count == 1 &&
                 originalTypeMethod.Parameters[0].ParameterType.FullName == "System.IntPtr") continue;
+            if (originalTypeMethod.HasOverrides) continue;
 
             var methodRewriteContext = new MethodRewriteContext(this, originalTypeMethod);
             myMethodContexts[originalTypeMethod] = methodRewriteContext;

--- a/Il2CppInterop.Generator/Passes/Pass70GenerateProperties.cs
+++ b/Il2CppInterop.Generator/Passes/Pass70GenerateProperties.cs
@@ -20,6 +20,8 @@ public static class Pass70GenerateProperties
 
                 foreach (var oldProperty in type.Properties)
                 {
+                    if ((oldProperty.GetMethod?.HasOverrides ?? false) || (oldProperty.SetMethod?.HasOverrides ?? false)) continue;
+
                     var unmangledPropertyName = UnmanglePropertyName(assemblyContext, oldProperty, typeContext.NewType,
                         propertyCountsByName);
 


### PR DESCRIPTION
Il2CppInterop doesn't generate proper interfaces anyways so they are not needed and all they do is mess with analyzers/IDEs

![image](https://user-images.githubusercontent.com/35262707/193630740-2680754a-b083-4be2-8604-d1317e50c16a.png)

This is a somewhat breaking change because you wont be able to access methods like `System_Collections_IList_get_Item` anymore (which ironically wasn't even recognized by rider), but it's not something like you can do in regular C# and you should cast to an interface anyways.