### PR TITLE
Add implicit conversions for primitives to il2cpp object

### DIFF
--- a/Il2CppInterop.Generator/Utils/CorlibReferences.cs
+++ b/Il2CppInterop.Generator/Utils/CorlibReferences.cs
@@ -40,6 +40,11 @@ internal static class CorlibReferences
         return module.ImportReference(typeof(string));
     }
 
+    public static TypeReference Short(this ModuleDefinition module)
+    {
+        return module.ImportReference(typeof(short));
+    }
+
     public static TypeReference Int(this ModuleDefinition module)
     {
         return module.ImportReference(typeof(int));
@@ -48,6 +53,31 @@ internal static class CorlibReferences
     public static TypeReference Long(this ModuleDefinition module)
     {
         return module.ImportReference(typeof(long));
+    }
+
+    public static TypeReference UShort(this ModuleDefinition module)
+    {
+        return module.ImportReference(typeof(ushort));
+    }
+
+    public static TypeReference UInt(this ModuleDefinition module)
+    {
+        return module.ImportReference(typeof(uint));
+    }
+
+    public static TypeReference ULong(this ModuleDefinition module)
+    {
+        return module.ImportReference(typeof(ulong));
+    }
+
+    public static TypeReference Float(this ModuleDefinition module)
+    {
+        return module.ImportReference(typeof(float));
+    }
+
+    public static TypeReference Double(this ModuleDefinition module)
+    {
+        return module.ImportReference(typeof(double));
     }
 
     public static TypeReference Type(this ModuleDefinition module)


### PR DESCRIPTION
Adds primitives conversions so you can easily use them in il2cpp methods that expect an object.
![image](https://user-images.githubusercontent.com/35262707/194957788-dfb35db9-5fe8-46c5-b5aa-770af0cbc9cc.png)
