### PR TITLE
Ensure Proper Layout for Non-ValueTypes

### DIFF
--- a/Il2CppInterop.Generator/Passes/Pass79UnstripTypes.cs
+++ b/Il2CppInterop.Generator/Passes/Pass79UnstripTypes.cs
@@ -79,6 +79,14 @@ public static class Pass79UnstripTypes
                 clonedType.DeclaringType = enclosingNewType;
             }
 
+            // Unity assemblies sometimes have struct layouts on classes.
+            // This gets overlooked on mono but not on coreclr.
+            if (!clonedType.IsValueType && (clonedType.IsExplicitLayout || clonedType.IsSequentialLayout))
+            {
+                clonedType.IsExplicitLayout = clonedType.IsSequentialLayout = false;
+                clonedType.IsAutoLayout = true;
+            }
+
             processedAssembly.RegisterTypeRewrite(new TypeRewriteContext(processedAssembly, null, clonedType));
             processedType = clonedType;
         }


### PR DESCRIPTION
On some Unity versions, some types will have layout attributes assigned to them even though they are not of ValueType.

A prime example is `UnityEngine.LightProbes` inside `UnityEngine.CoreModule.dll` on 2018.4.36f1 ([TestGame](https://github.com/BepInEx/TestGame/suites/8775722868/artifacts/398337413)).

This went unnoticed for a while until we switched to CoreCLR which is way stricter in terms of type loading.