### PR TITLE
Update sig scan for Class::GetFieldDefaultValue

### DIFF
--- a/Il2CppInterop.Runtime/Injection/InjectorHelpers.cs
+++ b/Il2CppInterop.Runtime/Injection/InjectorHelpers.cs
@@ -365,7 +365,7 @@ namespace Il2CppInterop.Runtime.Injection
             new MemoryUtils.SignatureDefinition
             {
                 pattern = "\x48\x89\x5C\x24\x08\x48\x89\x74\x24\x10\x57\x48\x83\xEC\x20\x48\x8B\x79\x10\x48\x8B\xD9\x48\x8B\xF2\x48\x2B\x9F",
-                mask = "xxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+                mask = "xxxxxxxxxxxxxx?xxxxxxxxxxxxx",
                 xref = false
             },
             // GTFO - Unity 2019.4.21 (x64)


### PR DESCRIPTION
Mask out the byte that sets the stack size - it's been observed to be both 0x20 and 0x40