### PR TITLE
Workaround garbage field offset values

### DIFF
--- a/Il2CppInterop.Generator/Passes/Pass11ComputeTypeSpecifics.cs
+++ b/Il2CppInterop.Generator/Passes/Pass11ComputeTypeSpecifics.cs
@@ -1,4 +1,5 @@
 using Il2CppInterop.Generator.Contexts;
+using Il2CppInterop.Generator.Extensions;
 
 namespace Il2CppInterop.Generator.Passes;
 
@@ -18,6 +19,13 @@ public static class Pass11ComputeTypeSpecifics
 
         foreach (var originalField in typeContext.OriginalType.Fields)
         {
+            // Sometimes il2cpp metadata has invalid field offsets for some reason (https://github.com/SamboyCoding/Cpp2IL/issues/167)
+            if (originalField.ExtractFieldOffset() >= 0x8000000)
+            {
+                typeContext.ComputedTypeSpecifics = TypeRewriteContext.TypeSpecifics.NonBlittableStruct;
+                return;
+            }
+
             if (originalField.IsStatic) continue;
 
             var fieldType = originalField.FieldType;

--- a/Il2CppInterop.Generator/Passes/Pass21GenerateValueTypeFields.cs
+++ b/Il2CppInterop.Generator/Passes/Pass21GenerateValueTypeFields.cs
@@ -42,10 +42,7 @@ public static class Pass21GenerateValueTypeFields
                                 ? assemblyContext.Imports.Module.IntPtr()
                                 : assemblyContext.RewriteTypeRef(field.FieldType));
 
-                        newField.Offset = Convert.ToInt32(
-                            (string)field.CustomAttributes
-                                .Single(it => it.AttributeType.Name == "FieldOffsetAttribute")
-                                .Fields.Single().Argument.Value, 16);
+                        newField.Offset = field.ExtractFieldOffset();
 
                         // Special case: bools in Il2Cpp are bytes
                         if (newField.FieldType.FullName == "System.Boolean")


### PR DESCRIPTION
Workarounds https://github.com/SamboyCoding/Cpp2IL/issues/167 by marking structs with fields that would crash the runtime as non-blittable