### PR TITLE
Fix FindGetTypeInfoFromTypeDefinitionIndex for Unity games built with IL2CPP Master

### DIFF
--- a/Il2CppInterop.Runtime/Injection/InjectorHelpers.cs
+++ b/Il2CppInterop.Runtime/Injection/InjectorHelpers.cs
@@ -216,7 +216,7 @@ namespace Il2CppInterop.Runtime.Injection
             if (s_InjectedClasses.TryGetValue(index, out IntPtr classPtr))
                 return (Il2CppClass*)classPtr;
 
-                return GetTypeInfoFromTypeDefinitionIndexOriginal(index);
+            return GetTypeInfoFromTypeDefinitionIndexOriginal(index);
         }
         private static readonly d_GetTypeInfoFromTypeDefinitionIndex GetTypeInfoFromTypeDefinitionIndexDetour = new(hkGetTypeInfoFromTypeDefinitionIndex);
         internal static d_GetTypeInfoFromTypeDefinitionIndex GetTypeInfoFromTypeDefinitionIndex;


### PR DESCRIPTION
This fixes FindGetTypeInfoFromTypeDefinitionIndex for Unity games built with C++ Compiler Configuration "Master" for IL2CPP (The Long Dark for example).
I'm not sure if this is IL2CPP Metadata v29 specific, but since we've only seen The Long Dark with this issue I'm assuming it's an v29 occasion only.