### PR TITLE
Don't unbox non-blittable generic valuetypes for parameter loading

### DIFF
--- a/Il2CppInterop.Common/XrefScans/XrefScannerLowLevel.cs
+++ b/Il2CppInterop.Common/XrefScans/XrefScannerLowLevel.cs
@@ -4,7 +4,12 @@ namespace Il2CppInterop.Common.XrefScans;
 
 public static class XrefScannerLowLevel
 {
-    public static IEnumerable<IntPtr> JumpTargets(IntPtr codeStart, bool ignoreRetn = false)
+    public static IEnumerable<IntPtr> JumpTargets(IntPtr codeStart)
+    {
+        return JumpTargets(codeStart, false);
+    }
+
+    public static IEnumerable<IntPtr> JumpTargets(IntPtr codeStart, bool ignoreRetn)
     {
         return JumpTargetsImpl(XrefScanner.DecoderForAddress(codeStart), ignoreRetn);
     }

--- a/Il2CppInterop.Common/XrefScans/XrefScannerLowLevel.cs
+++ b/Il2CppInterop.Common/XrefScans/XrefScannerLowLevel.cs
@@ -4,12 +4,7 @@ namespace Il2CppInterop.Common.XrefScans;
 
 public static class XrefScannerLowLevel
 {
-    public static IEnumerable<IntPtr> JumpTargets(IntPtr codeStart)
-    {
-        return JumpTargets(codeStart, false);
-    }
-
-    public static IEnumerable<IntPtr> JumpTargets(IntPtr codeStart, bool ignoreRetn)
+    public static IEnumerable<IntPtr> JumpTargets(IntPtr codeStart, bool ignoreRetn = false)
     {
         return JumpTargetsImpl(XrefScanner.DecoderForAddress(codeStart), ignoreRetn);
     }

--- a/Il2CppInterop.Generator/Extensions/ILGeneratorEx.cs
+++ b/Il2CppInterop.Generator/Extensions/ILGeneratorEx.cs
@@ -158,7 +158,7 @@ public static class ILGeneratorEx
 
     public static void EmitObjectToPointer(this ILProcessor body, TypeReference originalType, TypeReference newType,
         TypeRewriteContext enclosingType, int argumentIndex, bool valueTypeArgument0IsAPointer, bool allowNullable,
-        bool unboxNonBlittableType, out VariableDefinition? refVariable)
+        bool unboxNonBlittableType, bool unboxNonBlittableGeneric, out VariableDefinition? refVariable)
     {
         // input stack: not used
         // output stack: IntPtr to either Il2CppObject or IL2CPP value type
@@ -167,7 +167,7 @@ public static class ILGeneratorEx
         if (originalType is GenericParameter)
         {
             EmitObjectToPointerGeneric(body, originalType, newType, enclosingType, argumentIndex,
-                valueTypeArgument0IsAPointer, allowNullable, unboxNonBlittableType);
+                valueTypeArgument0IsAPointer, allowNullable, unboxNonBlittableGeneric);
             return;
         }
 

--- a/Il2CppInterop.Generator/Passes/Pass50GenerateMethods.cs
+++ b/Il2CppInterop.Generator/Passes/Pass50GenerateMethods.cs
@@ -167,7 +167,7 @@ public static class Pass50GenerateMethods
                         else
                         {
                             bodyBuilder.EmitObjectToPointer(originalMethod.Parameters[i].ParameterType, newParam.ParameterType,
-                                methodRewriteContext.DeclaringType, argOffset + i, false, true, true, out var refVar);
+                                methodRewriteContext.DeclaringType, argOffset + i, false, true, true, false, out var refVar);
                             if (refVar != null)
                                 byRefParams.Add((i, refVar));
                         }

--- a/Il2CppInterop.Generator/Passes/Pass50GenerateMethods.cs
+++ b/Il2CppInterop.Generator/Passes/Pass50GenerateMethods.cs
@@ -203,7 +203,7 @@ public static class Pass50GenerateMethods
                         bodyBuilder.Emit(OpCodes.Ldc_I4_0);
                     else
                         bodyBuilder.EmitObjectToPointer(originalMethod.DeclaringType, newMethod.DeclaringType, typeContext, 0,
-                            true, false, true, out _);
+                            true, false, true, true, out _);
 
                     bodyBuilder.Emit(OpCodes.Ldloc, argArray);
                     bodyBuilder.Emit(OpCodes.Ldloca, exceptionLocal);

--- a/Il2CppInterop.Generator/Utils/FieldAccessorGenerator.cs
+++ b/Il2CppInterop.Generator/Utils/FieldAccessorGenerator.cs
@@ -64,7 +64,7 @@ internal static class FieldAccessorGenerator
             getter.Body.Variables.Add(local0);
 
             getterBody.EmitObjectToPointer(fieldContext.DeclaringType.OriginalType, fieldContext.DeclaringType.NewType,
-                fieldContext.DeclaringType, 0, false, false, false, out _);
+                fieldContext.DeclaringType, 0, false, false, false, false, out _);
             getterBody.Emit(OpCodes.Ldsfld, fieldContext.PointerField);
             getterBody.Emit(OpCodes.Call, imports.IL2CPP_il2cpp_field_get_offset.Value);
             getterBody.Emit(OpCodes.Add);
@@ -94,13 +94,13 @@ internal static class FieldAccessorGenerator
         {
             setterBody.Emit(OpCodes.Ldsfld, fieldContext.PointerField);
             setterBody.EmitObjectToPointer(field.FieldType, property.PropertyType, fieldContext.DeclaringType, 0, false,
-                true, true, out _);
+                true, true, true, out _);
             setterBody.Emit(OpCodes.Call, imports.IL2CPP_il2cpp_field_static_set_value.Value);
         }
         else
         {
             setterBody.EmitObjectToPointer(fieldContext.DeclaringType.OriginalType, fieldContext.DeclaringType.NewType,
-                fieldContext.DeclaringType, 0, false, false, false, out _);
+                fieldContext.DeclaringType, 0, false, false, false, false, out _);
             setterBody.Emit(OpCodes.Dup);
             setterBody.Emit(OpCodes.Ldsfld, fieldContext.PointerField);
             setterBody.Emit(OpCodes.Call, imports.IL2CPP_il2cpp_field_get_offset.Value);

--- a/Il2CppInterop.Generator/Utils/UnstripGenerator.cs
+++ b/Il2CppInterop.Generator/Utils/UnstripGenerator.cs
@@ -72,7 +72,7 @@ public static class UnstripGenerator
             else
             {
                 body.EmitObjectToPointer(param.ParameterType, param.ParameterType, enclosingType, i + argOffset, false,
-                    true, true, out var refVar);
+                    true, true, true, out var refVar);
                 if (refVar != null)
                 {
                     Logger.Instance.LogTrace("Method {NewMethod} has a reference-typed ref parameter, this will be ignored",


### PR DESCRIPTION
Fixes an issue where non-blittable generic value types get unboxed when they shouldn't be during parameter loading. 

The most notable example is adding a boxed integer into a dictionary, the value field would have invalid data written to it.
```cs
private unsafe void Test() {
    long testLong = 2137;
    var testInt64 = new Il2CppSystem.Int64();
    *&testInt64.m_value = testLong;

    var dictionary = new Il2CppSystem.Collections.Generic.Dictionary<string, Il2CppSystem.Object>();
    dictionary.Add("test", testInt64.BoxIl2CppObject()); // PREV: Writes invalid data to value field
 
    foreach (var kv in dictionary)
    {
        Log.LogInfo(kv.Key);   // "test"
        Log.LogInfo(kv.Value); // 2137   (PREV: crash on access)
    }
}
```