### PR TITLE
Fix crash calling delegate invoke on il2cpp 29 or higher

### DIFF
--- a/Il2CppInterop.Runtime/Injection/ClassInjector.cs
+++ b/Il2CppInterop.Runtime/Injection/ClassInjector.cs
@@ -681,6 +681,7 @@ public static unsafe partial class ClassInjector
         {
             converted.InvokerMethod = Marshal.GetFunctionPointerForDelegate(GetOrCreateInvoker(monoMethod));
             converted.MethodPointer = Marshal.GetFunctionPointerForDelegate(GetOrCreateTrampoline(monoMethod));
+            converted.VirtualMethodPointer = converted.MethodPointer;
         }
 
         converted.Slot = ushort.MaxValue;

--- a/Il2CppInterop.Runtime/Runtime/VersionSpecific/MethodInfo/Interfaces.cs
+++ b/Il2CppInterop.Runtime/Runtime/VersionSpecific/MethodInfo/Interfaces.cs
@@ -14,6 +14,8 @@ public interface INativeMethodInfoStruct : INativeStruct
     ref IntPtr Name { get; }
     ref ushort Slot { get; }
     ref IntPtr MethodPointer { get; }
+
+    ref IntPtr VirtualMethodPointer { get; }
     unsafe ref Il2CppClass* Class { get; }
     ref IntPtr InvokerMethod { get; }
     unsafe ref Il2CppTypeStruct* ReturnType { get; }

--- a/Il2CppInterop.Runtime/Runtime/VersionSpecific/MethodInfo/MethodInfo_16_0.cs
+++ b/Il2CppInterop.Runtime/Runtime/VersionSpecific/MethodInfo/MethodInfo_16_0.cs
@@ -55,6 +55,7 @@ namespace Il2CppInterop.Runtime.Runtime.VersionSpecific.MethodInfo
             public ref IntPtr Name => ref *(IntPtr*)&_->name;
             public ref ushort Slot => ref _->slot;
             public ref IntPtr MethodPointer => ref *(IntPtr*)&_->method;
+            public ref IntPtr VirtualMethodPointer => ref *(IntPtr*)&_->method;
             public ref Il2CppClass* Class => ref _->declaring_type;
             public ref IntPtr InvokerMethod => ref *(IntPtr*)&_->invoker_method;
             public ref Il2CppTypeStruct* ReturnType => ref _->return_type;

--- a/Il2CppInterop.Runtime/Runtime/VersionSpecific/MethodInfo/MethodInfo_21_0.cs
+++ b/Il2CppInterop.Runtime/Runtime/VersionSpecific/MethodInfo/MethodInfo_21_0.cs
@@ -55,6 +55,7 @@ namespace Il2CppInterop.Runtime.Runtime.VersionSpecific.MethodInfo
             public ref IntPtr Name => ref *(IntPtr*)&_->name;
             public ref ushort Slot => ref _->slot;
             public ref IntPtr MethodPointer => ref *(IntPtr*)&_->methodPointer;
+            public ref IntPtr VirtualMethodPointer => ref *(IntPtr*)&_->methodPointer;
             public ref Il2CppClass* Class => ref _->declaring_type;
             public ref IntPtr InvokerMethod => ref *(IntPtr*)&_->invoker_method;
             public ref Il2CppTypeStruct* ReturnType => ref _->return_type;

--- a/Il2CppInterop.Runtime/Runtime/VersionSpecific/MethodInfo/MethodInfo_24_0.cs
+++ b/Il2CppInterop.Runtime/Runtime/VersionSpecific/MethodInfo/MethodInfo_24_0.cs
@@ -59,6 +59,7 @@ namespace Il2CppInterop.Runtime.Runtime.VersionSpecific.MethodInfo
             public ref IntPtr Name => ref *(IntPtr*)&_->name;
             public ref ushort Slot => ref _->slot;
             public ref IntPtr MethodPointer => ref *(IntPtr*)&_->methodPointer;
+            public ref IntPtr VirtualMethodPointer => ref *(IntPtr*)&_->methodPointer;
             public ref Il2CppClass* Class => ref _->klass;
             public ref IntPtr InvokerMethod => ref *(IntPtr*)&_->invoker_method;
             public ref Il2CppTypeStruct* ReturnType => ref _->return_type;

--- a/Il2CppInterop.Runtime/Runtime/VersionSpecific/MethodInfo/MethodInfo_24_1.cs
+++ b/Il2CppInterop.Runtime/Runtime/VersionSpecific/MethodInfo/MethodInfo_24_1.cs
@@ -58,6 +58,7 @@ namespace Il2CppInterop.Runtime.Runtime.VersionSpecific.MethodInfo
             public ref IntPtr Name => ref *(IntPtr*)&_->name;
             public ref ushort Slot => ref _->slot;
             public ref IntPtr MethodPointer => ref *(IntPtr*)&_->methodPointer;
+            public ref IntPtr VirtualMethodPointer => ref *(IntPtr*)&_->methodPointer;
             public ref Il2CppClass* Class => ref _->klass;
             public ref IntPtr InvokerMethod => ref *(IntPtr*)&_->invoker_method;
             public ref Il2CppTypeStruct* ReturnType => ref _->return_type;

--- a/Il2CppInterop.Runtime/Runtime/VersionSpecific/MethodInfo/MethodInfo_29_0.cs
+++ b/Il2CppInterop.Runtime/Runtime/VersionSpecific/MethodInfo/MethodInfo_29_0.cs
@@ -61,6 +61,7 @@ namespace Il2CppInterop.Runtime.Runtime.VersionSpecific.MethodInfo
             public ref IntPtr Name => ref *(IntPtr*)&_->name;
             public ref ushort Slot => ref _->slot;
             public ref IntPtr MethodPointer => ref *(IntPtr*)&_->methodPointer;
+            public ref IntPtr VirtualMethodPointer => ref *(IntPtr*)&_->virtualMethodPointer;
             public ref Il2CppClass* Class => ref _->klass;
             public ref IntPtr InvokerMethod => ref *(IntPtr*)&_->invoker_method;
             public ref Il2CppTypeStruct* ReturnType => ref _->return_type;

--- a/Il2CppInterop.Runtime/Runtime/VersionSpecific/MethodInfo/MethodInfo_29_1.cs
+++ b/Il2CppInterop.Runtime/Runtime/VersionSpecific/MethodInfo/MethodInfo_29_1.cs
@@ -59,6 +59,7 @@ namespace Il2CppInterop.Runtime.Runtime.VersionSpecific.MethodInfo
             public ref IntPtr Name => ref *(IntPtr*)&_->name;
             public ref ushort Slot => ref _->slot;
             public ref IntPtr MethodPointer => ref *(IntPtr*)&_->methodPointer;
+            public ref IntPtr VirtualMethodPointer => ref *(IntPtr*)&_->virtualMethodPointer;
             public ref Il2CppClass* Class => ref _->klass;
             public ref IntPtr InvokerMethod => ref *(IntPtr*)&_->invoker_method;
             public ref Il2CppTypeStruct* ReturnType => ref _->return_type;

--- a/Il2CppInterop.StructGenerator/Il2CppStructWrapperGenerator.cs
+++ b/Il2CppInterop.StructGenerator/Il2CppStructWrapperGenerator.cs
@@ -146,7 +146,8 @@ public static class Il2CppStructWrapperGenerator
                 classInternalsData = Regex.Replace(classInternalsData,
                     @"(union.{0,60}?genericMethod;.*?genericContainer(?:Handle)?;.*?});", "$1 generic_data;",
                     RegexOptions.Singleline);
-                if (File.Exists($"{classInternalsPath}_backup")) {
+                if (File.Exists($"{classInternalsPath}_backup"))
+                {
                     File.Delete($"{classInternalsPath}_backup");
                 }
                 File.Move(classInternalsPath, $"{classInternalsPath}_backup");

--- a/Il2CppInterop.StructGenerator/Il2CppStructWrapperGenerator.cs
+++ b/Il2CppInterop.StructGenerator/Il2CppStructWrapperGenerator.cs
@@ -138,20 +138,20 @@ public static class Il2CppStructWrapperGenerator
             var classInternalsIsTmp = true;
             // Graduated top of my class by the way
             {
-                var classInternalsData = File.ReadAllText(classInternalsPath);
-                // I have to do this because the lib I use doesn't recognize these unions, so I have to name them in the most disgusting way imaginable
-                classInternalsData = Regex.Replace(classInternalsData,
-                    @"(union.{0,60}?rgctx_data;.*?method(?:Definition|MetadataHandle);.*?});", "$1 runtime_data;",
-                    RegexOptions.Singleline);
-                classInternalsData = Regex.Replace(classInternalsData,
-                    @"(union.{0,60}?genericMethod;.*?genericContainer(?:Handle)?;.*?});", "$1 generic_data;",
-                    RegexOptions.Singleline);
-                if (File.Exists($"{classInternalsPath}_backup"))
+                if (!File.Exists($"{classInternalsPath}_backup"))
                 {
-                    File.Delete($"{classInternalsPath}_backup");
+                    var classInternalsData = File.ReadAllText(classInternalsPath);
+                    // I have to do this because the lib I use doesn't recognize these unions, so I have to name them in the most disgusting way imaginable
+                    classInternalsData = Regex.Replace(classInternalsData,
+                        @"(union.{0,60}?rgctx_data;.*?method(?:Definition|MetadataHandle);.*?});", "$1 runtime_data;",
+                        RegexOptions.Singleline);
+                    classInternalsData = Regex.Replace(classInternalsData,
+                        @"(union.{0,60}?genericMethod;.*?genericContainer(?:Handle)?;.*?});", "$1 generic_data;",
+                        RegexOptions.Singleline);
+
+                    File.Move(classInternalsPath, $"{classInternalsPath}_backup");
+                    File.WriteAllText(classInternalsPath, classInternalsData);
                 }
-                File.Move(classInternalsPath, $"{classInternalsPath}_backup");
-                File.WriteAllText(classInternalsPath, classInternalsData);
             }
             if (!SGenerators.ContainsKey(metadataVersion))
                 SGenerators[metadataVersion] = new List<VersionSpecificGenerator>();

--- a/Il2CppInterop.StructGenerator/Il2CppStructWrapperGenerator.cs
+++ b/Il2CppInterop.StructGenerator/Il2CppStructWrapperGenerator.cs
@@ -146,6 +146,9 @@ public static class Il2CppStructWrapperGenerator
                 classInternalsData = Regex.Replace(classInternalsData,
                     @"(union.{0,60}?genericMethod;.*?genericContainer(?:Handle)?;.*?});", "$1 generic_data;",
                     RegexOptions.Singleline);
+                if (File.Exists($"{classInternalsPath}_backup")) {
+                    File.Delete($"{classInternalsPath}_backup");
+                }
                 File.Move(classInternalsPath, $"{classInternalsPath}_backup");
                 File.WriteAllText(classInternalsPath, classInternalsData);
             }

--- a/Il2CppInterop.StructGenerator/TypeGenerators/Il2CppMethodInfoGenerator.cs
+++ b/Il2CppInterop.StructGenerator/TypeGenerators/Il2CppMethodInfoGenerator.cs
@@ -29,6 +29,7 @@ internal class Il2CppMethodInfoGenerator : VersionSpecificGenerator
         new ByRefWrapper("IntPtr", "Name", new[] { "name" }),
         new ByRefWrapper("ushort", "Slot", new[] { "slot" }),
         new ByRefWrapper("IntPtr", "MethodPointer", new[] { "methodPointer", "method" }),
+        new ByRefWrapper("IntPtr", "VirtualMethodPointer", new[] { "virtualMethodPointer", "methodPointer", "method" }),
         new ByRefWrapper("Il2CppClass*", "Class", new[] { "declaring_type", "klass" }),
         new ByRefWrapper("IntPtr", "InvokerMethod", new[] { "invoker_method" }),
         new ByRefWrapper("Il2CppTypeStruct*", "ReturnType", new[] { "return_type" }),

--- a/Il2CppInterop.StructGenerator/VersionSpecificGenerator.cs
+++ b/Il2CppInterop.StructGenerator/VersionSpecificGenerator.cs
@@ -119,6 +119,7 @@ internal abstract class VersionSpecificGenerator
                         if (nativeField is null) continue;
                         nativeName = nativeField.Name;
                         nativeType = nativeField.Type;
+                        break;
                     }
 
                     if (nativeName == null || nativeType == null)


### PR DESCRIPTION
This PR fixes that calling delegate `Invoke()` method caused a crash on il2cpp version 29 or higher.

This issue is caused by a new field in the `MethodInfo` class called `virtualMethodPointer`. Now when calling delegates il2cpp uses it to determine what to call. Since Il2CppInterop was not aware of that, it's value was null thus causing the crash.

I'm not entirely sure if it's supposed to have a value of it's own though. I have checked with a type from my game and every method there had `virtualMethodPointer` field equal to `methodPointer` field.

I have tested this on Unity 2021.3.14, il2cpp 29: no crashes calling delegates or UnityEvent's