### PR TITLE
Refactor hook creation

### DIFF
--- a/Il2CppInterop.Runtime/Injection/Hook.cs
+++ b/Il2CppInterop.Runtime/Injection/Hook.cs
@@ -22,7 +22,7 @@ namespace Il2CppInterop.Runtime.Injection
             if (isApplied) return;
 
             IntPtr methodPtr = FindTargetMethod();
-            Logger.Instance.LogTrace("{MethodName} found: 0x{MethodPtr}",TargetMethodName, methodPtr.ToInt64().ToString("X2"));
+            Logger.Instance.LogTrace("{MethodName} found: 0x{MethodPtr}", TargetMethodName, methodPtr.ToInt64().ToString("X2"));
 
             detour = GetDetour();
             Detour.Apply(methodPtr, detour, out original);

--- a/Il2CppInterop.Runtime/Injection/Hook.cs
+++ b/Il2CppInterop.Runtime/Injection/Hook.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using Il2CppInterop.Common;
+using Microsoft.Extensions.Logging;
+
+namespace Il2CppInterop.Runtime.Injection
+{
+    public abstract class Hook<T> where T : Delegate
+    {
+        private bool isApplied;
+        private T detour;
+        internal T method;
+        internal T original;
+
+
+        public abstract string TargetMethodName { get; }
+        public abstract T GetDetour();
+        public abstract IntPtr FindTargetMethod();
+
+        public void ApplyHook()
+        {
+            if (isApplied) return;
+
+            IntPtr methodPtr = FindTargetMethod();
+            Logger.Instance.LogTrace("{MethodName} found: 0x{MethodPtr}",TargetMethodName, methodPtr.ToInt64().ToString("X2"));
+
+            detour = GetDetour();
+            Detour.Apply(methodPtr, detour, out original);
+            method = Marshal.GetDelegateForFunctionPointer<T>(methodPtr);
+            isApplied = true;
+        }
+
+    }
+}

--- a/Il2CppInterop.Runtime/Injection/Hooks/Class_FromIl2CppType_Hook.cs
+++ b/Il2CppInterop.Runtime/Injection/Hooks/Class_FromIl2CppType_Hook.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Il2CppInterop.Common;
+using Il2CppInterop.Common.XrefScans;
+using Il2CppInterop.Runtime.Runtime;
+using Microsoft.Extensions.Logging;
+
+namespace Il2CppInterop.Runtime.Injection.Hooks
+{
+    internal unsafe class Class_FromIl2CppType_Hook : Hook<Class_FromIl2CppType_Hook.d_ClassFromIl2CppType>
+    {
+        /// Common version of the Il2CppType, the only thing that changed between unity version are the bitfields values that we don't use
+        internal readonly struct Il2CppType
+        {
+            public readonly void* data;
+            public readonly ushort attrs;
+            public readonly Il2CppTypeEnum type;
+            private readonly byte _bitfield;
+        }
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        internal delegate Il2CppClass* d_ClassFromIl2CppType(Il2CppType* type, bool throwOnError);
+
+        private Il2CppClass* hkClassFromIl2CppType(Il2CppType* type, bool throwOnError)
+        {
+            if ((nint)type->data < 0 && (type->type == Il2CppTypeEnum.IL2CPP_TYPE_CLASS || type->type == Il2CppTypeEnum.IL2CPP_TYPE_VALUETYPE))
+            {
+                InjectorHelpers.s_InjectedClasses.TryGetValue((nint)type->data, out var classPointer);
+                return (Il2CppClass*)classPointer;
+            }
+
+            return original(type, throwOnError);
+        }
+
+
+        public override d_ClassFromIl2CppType GetDetour() => new(hkClassFromIl2CppType);
+        public override string TargetMethodName => "Class::FromIl2CppType";
+
+        public override IntPtr FindTargetMethod()
+        {
+            var classFromTypeAPI = InjectorHelpers.GetIl2CppExport(nameof(IL2CPP.il2cpp_class_from_il2cpp_type));
+            Logger.Instance.LogTrace("il2cpp_class_from_il2cpp_type: 0x{ClassFromTypeApiAddress}", classFromTypeAPI.ToInt64().ToString("X2"));
+
+            return XrefScannerLowLevel.JumpTargets(classFromTypeAPI).Single();
+        }
+    }
+}

--- a/Il2CppInterop.Runtime/Injection/Hooks/Class_FromIl2CppType_Hook.cs
+++ b/Il2CppInterop.Runtime/Injection/Hooks/Class_FromIl2CppType_Hook.cs
@@ -8,8 +8,11 @@ using Microsoft.Extensions.Logging;
 
 namespace Il2CppInterop.Runtime.Injection.Hooks
 {
-    internal unsafe class Class_FromIl2CppType_Hook : Hook<Class_FromIl2CppType_Hook.d_ClassFromIl2CppType>
+    internal unsafe class Class_FromIl2CppType_Hook : Hook<Class_FromIl2CppType_Hook.MethodDelegate>
     {
+        public override string TargetMethodName => "Class::FromIl2CppType";
+        public override MethodDelegate GetDetour() => new(Hook);
+
         /// Common version of the Il2CppType, the only thing that changed between unity version are the bitfields values that we don't use
         internal readonly struct Il2CppType
         {
@@ -20,9 +23,9 @@ namespace Il2CppInterop.Runtime.Injection.Hooks
         }
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate Il2CppClass* d_ClassFromIl2CppType(Il2CppType* type, bool throwOnError);
+        internal delegate Il2CppClass* MethodDelegate(Il2CppType* type, bool throwOnError);
 
-        private Il2CppClass* hkClassFromIl2CppType(Il2CppType* type, bool throwOnError)
+        private Il2CppClass* Hook(Il2CppType* type, bool throwOnError)
         {
             if ((nint)type->data < 0 && (type->type == Il2CppTypeEnum.IL2CPP_TYPE_CLASS || type->type == Il2CppTypeEnum.IL2CPP_TYPE_VALUETYPE))
             {
@@ -32,10 +35,6 @@ namespace Il2CppInterop.Runtime.Injection.Hooks
 
             return original(type, throwOnError);
         }
-
-
-        public override d_ClassFromIl2CppType GetDetour() => new(hkClassFromIl2CppType);
-        public override string TargetMethodName => "Class::FromIl2CppType";
 
         public override IntPtr FindTargetMethod()
         {

--- a/Il2CppInterop.Runtime/Injection/Hooks/Class_FromName_Hook.cs
+++ b/Il2CppInterop.Runtime/Injection/Hooks/Class_FromName_Hook.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Il2CppInterop.Common;
+using Il2CppInterop.Common.XrefScans;
+using Il2CppInterop.Runtime.Runtime;
+using Microsoft.Extensions.Logging;
+
+namespace Il2CppInterop.Runtime.Injection.Hooks
+{
+    internal unsafe class Class_FromName_Hook : Hook<Class_FromName_Hook.d_ClassFromName>
+    {
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        internal delegate Il2CppClass* d_ClassFromName(Il2CppImage* image, IntPtr _namespace, IntPtr name);
+
+        private Il2CppClass* hkClassFromName(Il2CppImage* image, IntPtr _namespace, IntPtr name)
+        {
+            Il2CppClass* classPtr = original(image, _namespace, name);
+
+            if (classPtr == null)
+            {
+                string namespaze = Marshal.PtrToStringAnsi(_namespace);
+                string className = Marshal.PtrToStringAnsi(name);
+                InjectorHelpers.s_ClassNameLookup.TryGetValue((namespaze, className, (IntPtr)image), out IntPtr injectedClass);
+                classPtr = (Il2CppClass*)injectedClass;
+            }
+
+            return classPtr;
+        }
+
+
+        public override d_ClassFromName GetDetour() => new(hkClassFromName);
+        public override string TargetMethodName => "Class::FromName";
+
+        public override IntPtr FindTargetMethod()
+        {
+            var classFromNameAPI = InjectorHelpers.GetIl2CppExport(nameof(IL2CPP.il2cpp_class_from_name));
+            Logger.Instance.LogTrace("il2cpp_class_from_name: 0x{ClassFromNameApiAddress}", classFromNameAPI.ToInt64().ToString("X2"));
+
+            return XrefScannerLowLevel.JumpTargets(classFromNameAPI).Single();
+        }
+    }
+}

--- a/Il2CppInterop.Runtime/Injection/Hooks/Class_FromName_Hook.cs
+++ b/Il2CppInterop.Runtime/Injection/Hooks/Class_FromName_Hook.cs
@@ -8,12 +8,15 @@ using Microsoft.Extensions.Logging;
 
 namespace Il2CppInterop.Runtime.Injection.Hooks
 {
-    internal unsafe class Class_FromName_Hook : Hook<Class_FromName_Hook.d_ClassFromName>
+    internal unsafe class Class_FromName_Hook : Hook<Class_FromName_Hook.MethodDelegate>
     {
-        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate Il2CppClass* d_ClassFromName(Il2CppImage* image, IntPtr _namespace, IntPtr name);
+        public override string TargetMethodName => "Class::FromName";
+        public override MethodDelegate GetDetour() => new(Hook);
 
-        private Il2CppClass* hkClassFromName(Il2CppImage* image, IntPtr _namespace, IntPtr name)
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        internal delegate Il2CppClass* MethodDelegate(Il2CppImage* image, IntPtr _namespace, IntPtr name);
+
+        private Il2CppClass* Hook(Il2CppImage* image, IntPtr _namespace, IntPtr name)
         {
             Il2CppClass* classPtr = original(image, _namespace, name);
 
@@ -27,10 +30,6 @@ namespace Il2CppInterop.Runtime.Injection.Hooks
 
             return classPtr;
         }
-
-
-        public override d_ClassFromName GetDetour() => new(hkClassFromName);
-        public override string TargetMethodName => "Class::FromName";
 
         public override IntPtr FindTargetMethod()
         {

--- a/Il2CppInterop.Runtime/Injection/Hooks/Class_GetFieldDefaultValue_Hook.cs
+++ b/Il2CppInterop.Runtime/Injection/Hooks/Class_GetFieldDefaultValue_Hook.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Il2CppInterop.Common;
+using Il2CppInterop.Common.Extensions;
+using Il2CppInterop.Common.XrefScans;
+using Il2CppInterop.Runtime.Runtime;
+using Il2CppInterop.Runtime.Runtime.VersionSpecific.Class;
+using Il2CppInterop.Runtime.Runtime.VersionSpecific.FieldInfo;
+using Il2CppInterop.Runtime.Startup;
+using Microsoft.Extensions.Logging;
+
+namespace Il2CppInterop.Runtime.Injection.Hooks
+{
+    internal unsafe class Class_GetFieldDefaultValue_Hook : Hook<Class_GetFieldDefaultValue_Hook.d_ClassGetFieldDefaultValue>
+    {
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        internal delegate byte* d_ClassGetFieldDefaultValue(Il2CppFieldInfo* field, out Il2CppTypeStruct* type);
+
+        private byte* hkClassGetFieldDefaultValue(Il2CppFieldInfo* field, out Il2CppTypeStruct* type)
+        {
+            if (EnumInjector.GetDefaultValueOverride(field, out IntPtr newDefaultPtr))
+            {
+                INativeFieldInfoStruct wrappedField = UnityVersionHandler.Wrap(field);
+                INativeClassStruct wrappedParent = UnityVersionHandler.Wrap(wrappedField.Parent);
+                INativeClassStruct wrappedElementClass = UnityVersionHandler.Wrap(wrappedParent.ElementClass);
+                type = wrappedElementClass.ByValArg.TypePointer;
+                return (byte*)newDefaultPtr;
+            }
+            return original(field, out type);
+        }
+
+        public override d_ClassGetFieldDefaultValue GetDetour() => new(hkClassGetFieldDefaultValue);
+        public override string TargetMethodName => "Class::GetDefaultFieldValue";
+
+        private static readonly MemoryUtils.SignatureDefinition[] s_ClassGetFieldDefaultValueSignatures =
+        {
+            // Test Game - Unity 2021.3.4 (x64)
+            new MemoryUtils.SignatureDefinition
+            {
+                pattern = "\x48\x89\x5C\x24\x08\x48\x89\x74\x24\x10\x57\x48\x83\xEC\x20\x48\x8B\x79\x10\x48\x8B\xD9\x48\x8B\xF2\x48\x2B\x9F",
+                mask = "xxxxxxxxxxxxxx?xxxxxxxxxxxxx",
+                xref = false
+            },
+            // GTFO - Unity 2019.4.21 (x64)
+            new MemoryUtils.SignatureDefinition
+            {
+                pattern = "\x48\x89\x5C\x24\x08\x57\x48\x83\xEC\x20\x48\x8B\x41\x10\x48\x8B\xD9\x48\x8B",
+                mask = "xxxxxxxxxxxxxxxxxxx",
+                xref = false
+            },
+            // Evony - Unity 2018.4.0 (x86)
+            new MemoryUtils.SignatureDefinition
+            {
+                pattern = "\x55\x8B\xEC\x56\xFF\x75\x08\xE8\x00\x00\x00\x00\x8B\xF0\x83\xC4\x04\x85\xF6",
+                mask = "xxxxxxxx????xxxxxxx",
+                xref = false
+            },
+        };
+
+        private static nint FindClassGetFieldDefaultValueXref(bool forceICallMethod = false)
+        {
+            nint classGetDefaultFieldValue = 0;
+            if (forceICallMethod)
+            {
+                // MonoField isn't present on 2021.2.0+
+                var monoFieldType = InjectorHelpers.Il2CppMscorlib.GetTypesSafe().SingleOrDefault((x) => x.Name is "MonoField");
+                if (monoFieldType == null)
+                    throw new Exception($"Unity {Il2CppInteropRuntime.Instance.UnityVersion} is not supported at the moment: MonoField isn't present in Il2Cppmscorlib.dll for unity version, unable to fetch icall");
+
+                var monoFieldGetValueInternalThunk = InjectorHelpers.GetIl2CppMethodPointer(monoFieldType.GetMethod(nameof(Il2CppSystem.Reflection.MonoField.GetValueInternal)));
+                Logger.Instance.LogTrace("Il2CppSystem.Reflection.MonoField::thunk_GetValueInternal: 0x{MonoFieldGetValueInternalThunkAddress}", monoFieldGetValueInternalThunk.ToInt64().ToString("X2"));
+
+                var monoFieldGetValueInternal = XrefScannerLowLevel.JumpTargets(monoFieldGetValueInternalThunk).Single();
+                Logger.Instance.LogTrace("Il2CppSystem.Reflection.MonoField::GetValueInternal: 0x{MonoFieldGetValueInternalAddress}", monoFieldGetValueInternal.ToInt64().ToString("X2"));
+
+                // Field::GetValueObject could be inlined with Field::GetValueObjectForThread
+                var fieldGetValueObject = XrefScannerLowLevel.JumpTargets(monoFieldGetValueInternal).Single();
+                Logger.Instance.LogTrace("Field::GetValueObject: 0x{FieldGetValueObjectAddress}", fieldGetValueObject.ToInt64().ToString("X2"));
+
+                var fieldGetValueObjectForThread = XrefScannerLowLevel.JumpTargets(fieldGetValueObject).Last();
+                Logger.Instance.LogTrace("Field::GetValueObjectForThread: 0x{FieldGetValueObjectForThreadAddress}", fieldGetValueObjectForThread.ToInt64().ToString("X2"));
+
+                classGetDefaultFieldValue = XrefScannerLowLevel.JumpTargets(fieldGetValueObjectForThread).ElementAt(2);
+            }
+            else
+            {
+                var getStaticFieldValueAPI = InjectorHelpers.GetIl2CppExport(nameof(IL2CPP.il2cpp_field_static_get_value));
+                Logger.Instance.LogTrace("il2cpp_field_static_get_value: 0x{GetStaticFieldValueApiAddress}", getStaticFieldValueAPI.ToInt64().ToString("X2"));
+
+                var getStaticFieldValue = XrefScannerLowLevel.JumpTargets(getStaticFieldValueAPI).Single();
+                Logger.Instance.LogTrace("Field::StaticGetValue: 0x{GetStaticFieldValueAddress}", getStaticFieldValue.ToInt64().ToString("X2"));
+
+                var getStaticFieldValueInternal = XrefScannerLowLevel.JumpTargets(getStaticFieldValue).Last();
+                Logger.Instance.LogTrace("Field::StaticGetValueInternal: 0x{GetStaticFieldValueInternalAddress}", getStaticFieldValueInternal.ToInt64().ToString("X2"));
+
+                var getStaticFieldValueInternalTargets = XrefScannerLowLevel.JumpTargets(getStaticFieldValueInternal).ToArray();
+
+                if (getStaticFieldValueInternalTargets.Length == 0) return FindClassGetFieldDefaultValueXref(true);
+
+                classGetDefaultFieldValue = getStaticFieldValueInternalTargets.Length == 3 ? getStaticFieldValueInternalTargets.Last() : getStaticFieldValueInternalTargets.First();
+            }
+            return classGetDefaultFieldValue;
+        }
+
+        public override IntPtr FindTargetMethod()
+        {
+            // NOTE: In some cases this pointer will be MetadataCache::GetFieldDefaultValueForField due to Field::GetDefaultFieldValue being
+            // inlined but we'll treat it the same even though it doesn't receive the type parameter the RDX register
+            // doesn't get cleared so we still get the same parameters
+            var classGetDefaultFieldValue = s_ClassGetFieldDefaultValueSignatures
+                .Select(s => MemoryUtils.FindSignatureInModule(InjectorHelpers.Il2CppModule, s))
+                .FirstOrDefault(p => p != 0);
+
+            if (classGetDefaultFieldValue == 0)
+            {
+                Logger.Instance.LogTrace("Couldn't fetch Class::GetDefaultFieldValue with signatures, using method traversal");
+                classGetDefaultFieldValue = FindClassGetFieldDefaultValueXref();
+            }
+
+            return classGetDefaultFieldValue;
+        }
+    }
+}

--- a/Il2CppInterop.Runtime/Injection/Hooks/GenericMethod_GetMethod_Hook.cs
+++ b/Il2CppInterop.Runtime/Injection/Hooks/GenericMethod_GetMethod_Hook.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Il2CppInterop.Common;
+using Il2CppInterop.Common.XrefScans;
+using Il2CppInterop.Runtime.Runtime;
+using Microsoft.Extensions.Logging;
+
+namespace Il2CppInterop.Runtime.Injection.Hooks
+{
+    internal unsafe class GenericMethod_GetMethod_Hook : Hook<GenericMethod_GetMethod_Hook.d_GenericMethodGetMethod>
+    {
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        internal delegate Il2CppMethodInfo* d_GenericMethodGetMethod(Il2CppGenericMethod* gmethod, bool copyMethodPtr);
+
+        internal Il2CppMethodInfo* hkGenericMethodGetMethod(Il2CppGenericMethod* gmethod, bool copyMethodPtr)
+        {
+            if (ClassInjector.InflatedMethodFromContextDictionary.TryGetValue((IntPtr)gmethod->methodDefinition, out var methods))
+            {
+                var instancePointer = gmethod->context.method_inst;
+                if (methods.Item2.TryGetValue((IntPtr)instancePointer, out var inflatedMethodPointer))
+                    return (Il2CppMethodInfo*)inflatedMethodPointer;
+
+                var typeArguments = new Type[instancePointer->type_argc];
+                for (var i = 0; i < instancePointer->type_argc; i++)
+                    typeArguments[i] = ClassInjector.SystemTypeFromIl2CppType(instancePointer->type_argv[i]);
+                var inflatedMethod = methods.Item1.MakeGenericMethod(typeArguments);
+                Logger.Instance.LogTrace("Inflated method: {InflatedMethod}", inflatedMethod.Name);
+                inflatedMethodPointer = (IntPtr)ClassInjector.ConvertMethodInfo(inflatedMethod,
+                    UnityVersionHandler.Wrap(UnityVersionHandler.Wrap(gmethod->methodDefinition).Class));
+                methods.Item2.Add((IntPtr)instancePointer, inflatedMethodPointer);
+
+                return (Il2CppMethodInfo*)inflatedMethodPointer;
+            }
+
+            return original(gmethod, copyMethodPtr);
+        }
+
+        private static readonly MemoryUtils.SignatureDefinition[] s_GenericMethodGetMethodSignatures =
+        {
+            // Unity 2021.2.5 (x64)
+            new MemoryUtils.SignatureDefinition
+            {
+                pattern = "\x48\x89\x5C\x24\x08\x48\x89\x6C\x24\x10\x56\x57\x41\x54\x41\x56\x41\x57\x48\x81\xEC\xB0\x00",
+                mask = "xxxxxxxxxxxxxxxxxxxxxxx",
+                xref = false
+            }
+        };
+
+        public override d_GenericMethodGetMethod GetDetour() => new(hkGenericMethodGetMethod);
+        public override string TargetMethodName => "GenericMethod::GetMethod";
+
+        public override IntPtr FindTargetMethod()
+        {
+            // On Unity 2021.2+, the 3 parameter shim can be inlined and optimized by the compiler
+            // which moves the method we're looking for
+            var genericMethodGetMethod = s_GenericMethodGetMethodSignatures
+                .Select(s => MemoryUtils.FindSignatureInModule(InjectorHelpers.Il2CppModule, s))
+                .FirstOrDefault(p => p != 0);
+
+            if (genericMethodGetMethod == 0)
+            {
+                var getVirtualMethodAPI = InjectorHelpers.GetIl2CppExport(nameof(IL2CPP.il2cpp_object_get_virtual_method));
+                Logger.Instance.LogTrace("il2cpp_object_get_virtual_method: 0x{GetVirtualMethodApiAddress}", getVirtualMethodAPI.ToInt64().ToString("X2"));
+
+                var getVirtualMethod = XrefScannerLowLevel.JumpTargets(getVirtualMethodAPI).Single();
+                Logger.Instance.LogTrace("Object::GetVirtualMethod: 0x{GetVirtualMethodAddress}", getVirtualMethod.ToInt64().ToString("X2"));
+
+                var getVirtualMethodXrefs = XrefScannerLowLevel.JumpTargets(getVirtualMethod).ToArray();
+
+                // If the game is built with IL2CPP Master setting, this will return 0 entries, so we do another xref scan with retn instructions ignored.
+                if (getVirtualMethodXrefs.Length == 0)
+                {
+                    genericMethodGetMethod = XrefScannerLowLevel.JumpTargets(getVirtualMethod, true).Last();
+                }
+                else
+                {
+                    genericMethodGetMethod = getVirtualMethodXrefs.Last();
+
+                    var targetTargets = XrefScannerLowLevel.JumpTargets(genericMethodGetMethod).Take(2).ToArray();
+                    if (targetTargets.Length == 1 && UnityVersionHandler.IsMetadataV29OrHigher) // U2021.2.0+, there's additional shim that takes 3 parameters
+                        genericMethodGetMethod = targetTargets[0];
+                }
+            }
+
+            return genericMethodGetMethod;
+        }
+    }
+}

--- a/Il2CppInterop.Runtime/Injection/Hooks/MetadataCache_GetTypeInfoFromTypeDefinitionIndex_Hook.cs
+++ b/Il2CppInterop.Runtime/Injection/Hooks/MetadataCache_GetTypeInfoFromTypeDefinitionIndex_Hook.cs
@@ -10,22 +10,21 @@ using Microsoft.Extensions.Logging;
 namespace Il2CppInterop.Runtime.Injection.Hooks
 {
     internal unsafe class MetadataCache_GetTypeInfoFromTypeDefinitionIndex_Hook :
-        Hook<MetadataCache_GetTypeInfoFromTypeDefinitionIndex_Hook.d_GetTypeInfoFromTypeDefinitionIndex>
+        Hook<MetadataCache_GetTypeInfoFromTypeDefinitionIndex_Hook.MethodDelegate>
     {
+        public override string TargetMethodName => "MetadataCache::GetTypeInfoFromTypeDefinitionIndex";
+        public override MethodDelegate GetDetour() => new(Hook);
+
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate Il2CppClass* d_GetTypeInfoFromTypeDefinitionIndex(int index);
+        internal delegate Il2CppClass* MethodDelegate(int index);
 
-
-        private Il2CppClass* hkGetTypeInfoFromTypeDefinitionIndex(int index)
+        private Il2CppClass* Hook(int index)
         {
             if (InjectorHelpers.s_InjectedClasses.TryGetValue(index, out IntPtr classPtr))
                 return (Il2CppClass*)classPtr;
 
             return original(index);
         }
-
-        public override d_GetTypeInfoFromTypeDefinitionIndex GetDetour() => new(hkGetTypeInfoFromTypeDefinitionIndex);
-        public override string TargetMethodName => "MetadataCache::GetTypeInfoFromTypeDefinitionIndex";
 
         private IntPtr FindGetTypeInfoFromTypeDefinitionIndex(bool forceICallMethod = false)
         {

--- a/Il2CppInterop.Runtime/Injection/Hooks/MetadataCache_GetTypeInfoFromTypeDefinitionIndex_Hook.cs
+++ b/Il2CppInterop.Runtime/Injection/Hooks/MetadataCache_GetTypeInfoFromTypeDefinitionIndex_Hook.cs
@@ -1,0 +1,123 @@
+﻿using System;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Il2CppInterop.Common;
+using Il2CppInterop.Common.XrefScans;
+using Il2CppInterop.Runtime.Runtime;
+using Il2CppInterop.Runtime.Startup;
+using Microsoft.Extensions.Logging;
+
+namespace Il2CppInterop.Runtime.Injection.Hooks
+{
+    internal unsafe class MetadataCache_GetTypeInfoFromTypeDefinitionIndex_Hook :
+        Hook<MetadataCache_GetTypeInfoFromTypeDefinitionIndex_Hook.d_GetTypeInfoFromTypeDefinitionIndex>
+    {
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        internal delegate Il2CppClass* d_GetTypeInfoFromTypeDefinitionIndex(int index);
+
+
+        private Il2CppClass* hkGetTypeInfoFromTypeDefinitionIndex(int index)
+        {
+            if (InjectorHelpers.s_InjectedClasses.TryGetValue(index, out IntPtr classPtr))
+                return (Il2CppClass*)classPtr;
+
+            return original(index);
+        }
+
+        public override d_GetTypeInfoFromTypeDefinitionIndex GetDetour() => new(hkGetTypeInfoFromTypeDefinitionIndex);
+        public override string TargetMethodName => "MetadataCache::GetTypeInfoFromTypeDefinitionIndex";
+
+        private IntPtr FindGetTypeInfoFromTypeDefinitionIndex(bool forceICallMethod = false)
+        {
+            IntPtr getTypeInfoFromTypeDefinitionIndex = IntPtr.Zero;
+
+            // il2cpp_image_get_class is added in 2018.3.0f1
+            if (Il2CppInteropRuntime.Instance.UnityVersion < new Version(2018, 3, 0) || forceICallMethod)
+            {
+                // (Kasuromi): RuntimeHelpers.InitializeArray calls an il2cpp icall, proxy function does some magic before it invokes it
+                // https://github.com/Unity-Technologies/mono/blob/unity-2018.2/mcs/class/corlib/System.Runtime.CompilerServices/RuntimeHelpers.cs#L53-L54
+                IntPtr runtimeHelpersInitializeArray = InjectorHelpers.GetIl2CppMethodPointer(
+                    typeof(Il2CppSystem.Runtime.CompilerServices.RuntimeHelpers)
+                        .GetMethod("InitializeArray", new Type[] { typeof(Il2CppSystem.Array), typeof(IntPtr) })
+                );
+                Logger.Instance.LogTrace("Il2CppSystem.Runtime.CompilerServices.RuntimeHelpers::InitializeArray: 0x{RuntimeHelpersInitializeArrayAddress}", runtimeHelpersInitializeArray.ToInt64().ToString("X2"));
+
+                var runtimeHelpersInitializeArrayICall = XrefScannerLowLevel.JumpTargets(runtimeHelpersInitializeArray).Last();
+                if (XrefScannerLowLevel.JumpTargets(runtimeHelpersInitializeArrayICall).Count() == 1)
+                {
+                    // is a thunk function
+                    Logger.Instance.LogTrace("RuntimeHelpers::thunk_InitializeArray: 0x{RuntimeHelpersInitializeArrayICallAddress}", runtimeHelpersInitializeArrayICall.ToInt64().ToString("X2"));
+                    runtimeHelpersInitializeArrayICall = XrefScannerLowLevel.JumpTargets(runtimeHelpersInitializeArrayICall).Single();
+                }
+
+                Logger.Instance.LogTrace("RuntimeHelpers::InitializeArray: 0x{RuntimeHelpersInitializeArrayICallAddress}", runtimeHelpersInitializeArrayICall.ToInt64().ToString("X2"));
+
+                var typeGetUnderlyingType = XrefScannerLowLevel.JumpTargets(runtimeHelpersInitializeArrayICall).ElementAt(1);
+                Logger.Instance.LogTrace("Type::GetUnderlyingType: 0x{TypeGetUnderlyingTypeAddress}", typeGetUnderlyingType.ToInt64().ToString("X2"));
+
+                getTypeInfoFromTypeDefinitionIndex = XrefScannerLowLevel.JumpTargets(typeGetUnderlyingType).First();
+            }
+            else
+            {
+                var imageGetClassAPI = InjectorHelpers.GetIl2CppExport(nameof(IL2CPP.il2cpp_image_get_class));
+                Logger.Instance.LogTrace("il2cpp_image_get_class: 0x{ImageGetClassApiAddress}", imageGetClassAPI.ToInt64().ToString("X2"));
+
+                var imageGetType = XrefScannerLowLevel.JumpTargets(imageGetClassAPI).Single();
+                Logger.Instance.LogTrace("Image::GetType: 0x{ImageGetTypeAddress}", imageGetType.ToInt64().ToString("X2"));
+
+                var imageGetTypeXrefs = XrefScannerLowLevel.JumpTargets(imageGetType).ToArray();
+
+                if (imageGetTypeXrefs.Length == 0)
+                {
+                    // (Kasuromi): Image::GetType appears to be inlined in il2cpp_image_get_class on some occasions,
+                    // if the unconditional xrefs are 0 then we are in the correct method (seen on unity 2019.3.15)
+                    getTypeInfoFromTypeDefinitionIndex = imageGetType;
+                }
+                else getTypeInfoFromTypeDefinitionIndex = imageGetTypeXrefs[0];
+                if ((getTypeInfoFromTypeDefinitionIndex.ToInt64() & 0xF) != 0)
+                {
+                    Logger.Instance.LogTrace("Image::GetType xref wasn't aligned, attempting to resolve from icall");
+                    return FindGetTypeInfoFromTypeDefinitionIndex(true);
+                }
+                if (imageGetTypeXrefs.Count() > 1 && UnityVersionHandler.IsMetadataV29OrHigher)
+                {
+                    // (Kasuromi): metadata v29 introduces handles and adds extra calls, a check for unity versions might be necessary in the future
+
+                    Logger.Instance.LogTrace($"imageGetTypeXrefs.Length: {imageGetTypeXrefs.Length}");
+
+                    // If the game is built as IL2CPP Master, GetAssemblyTypeHandle is inlined, xrefs length is 3 and it's the first function call,
+                    // if not, it's the last call.
+                    var getTypeInfoFromHandle = imageGetTypeXrefs.Length == 2 ? imageGetTypeXrefs.Last() : imageGetTypeXrefs.First();
+
+                    Logger.Instance.LogTrace($"getTypeInfoFromHandle: {getTypeInfoFromHandle:X2}");
+
+                    var getTypeInfoFromHandleXrefs = XrefScannerLowLevel.JumpTargets(getTypeInfoFromHandle).ToArray();
+
+                    // If getTypeInfoFromHandle xrefs is not a single call, it's the function we want, if not, we keep xrefing until we find it
+                    if (getTypeInfoFromHandleXrefs.Length != 1)
+                    {
+                        getTypeInfoFromTypeDefinitionIndex = getTypeInfoFromHandle;
+                        Logger.Instance.LogTrace($"Xrefs length was not 1, getTypeInfoFromTypeDefinitionIndex: {getTypeInfoFromTypeDefinitionIndex:X2}");
+                    }
+                    else
+                    {
+                        // Two calls, second one (GetIndexForTypeDefinitionInternal) is inlined
+                        getTypeInfoFromTypeDefinitionIndex = getTypeInfoFromHandleXrefs.Single();
+                        // Xref scanner is sometimes confused about getTypeInfoFromHandle so we walk all the thunks until we hit the big method we need
+                        while (XrefScannerLowLevel.JumpTargets(getTypeInfoFromTypeDefinitionIndex).ToArray().Length == 1)
+                        {
+                            getTypeInfoFromTypeDefinitionIndex = XrefScannerLowLevel.JumpTargets(getTypeInfoFromTypeDefinitionIndex).Single();
+                        }
+                    }
+                }
+            }
+
+            return getTypeInfoFromTypeDefinitionIndex;
+        }
+
+        public override IntPtr FindTargetMethod()
+        {
+            return FindGetTypeInfoFromTypeDefinitionIndex();
+        }
+    }
+}


### PR DESCRIPTION
This PR improves the way hooks are done. Now a hook is created by implementing Hook class. The only things that need to be defined are the hook delegate, hook method and find target method function. 

This removes some boilerplate code, and splits hooks across files for more modularity.
No functional changes. Tested on Core Keeper 2021.3.14f