### PR TITLE
fixed deobfuscation map generation

### DIFF
--- a/Il2CppInterop.Generator/Contexts/AssemblyRewriteContext.cs
+++ b/Il2CppInterop.Generator/Contexts/AssemblyRewriteContext.cs
@@ -130,7 +130,8 @@ public class AssemblyRewriteContext
             return Imports.Module.Void();
 
         if (typeRef.FullName == "System.String")
-            return Imports.Module.String();
+            return sourceModule.ImportReference(GlobalContext.GetAssemblyByName("mscorlib")
+                .GetTypeByName("System.String").NewType);
 
         if (typeRef.FullName == "System.Object")
             return sourceModule.ImportReference(GlobalContext.GetAssemblyByName("mscorlib")

--- a/Il2CppInterop.Generator/Contexts/AssemblyRewriteContext.cs
+++ b/Il2CppInterop.Generator/Contexts/AssemblyRewriteContext.cs
@@ -153,7 +153,7 @@ public class AssemblyRewriteContext
         {
             return Imports.Il2CppObjectBase;
         }
-        if(originalTypeDef == null)
+        if (originalTypeDef == null)
             return Imports.Il2CppObjectBase;
         var targetAssembly = GlobalContext.GetNewAssemblyForOriginal(originalTypeDef.Module.Assembly);
         var target = targetAssembly.GetContextForOriginalType(originalTypeDef).NewType;

--- a/Il2CppInterop.Generator/Contexts/AssemblyRewriteContext.cs
+++ b/Il2CppInterop.Generator/Contexts/AssemblyRewriteContext.cs
@@ -153,6 +153,8 @@ public class AssemblyRewriteContext
         {
             return Imports.Il2CppObjectBase;
         }
+        if(originalTypeDef == null)
+            return Imports.Il2CppObjectBase;
         var targetAssembly = GlobalContext.GetNewAssemblyForOriginal(originalTypeDef.Module.Assembly);
         var target = targetAssembly.GetContextForOriginalType(originalTypeDef).NewType;
 

--- a/Il2CppInterop.Generator/Contexts/RewriteGlobalContext.cs
+++ b/Il2CppInterop.Generator/Contexts/RewriteGlobalContext.cs
@@ -84,13 +84,31 @@ public class RewriteGlobalContext : IDisposable
 
     public AssemblyRewriteContext GetNewAssemblyForOriginal(AssemblyDefinition oldAssembly)
     {
-        return myAssembliesByOld[oldAssembly];
+        try
+        {
+            return myAssembliesByOld[oldAssembly];
+        }
+        catch
+        {
+            foreach (var assembly in myAssembliesByOld.Keys)
+            {
+                if (assembly.Name == oldAssembly.Name)
+                    return myAssembliesByOld[assembly];
+            }
+            return myAssemblies.TryGetValue("Il2Cppmscorlib", out var result2) ? result2 : null;
+        }
     }
 
     public TypeRewriteContext GetNewTypeForOriginal(TypeDefinition originalType)
     {
-        return GetNewAssemblyForOriginal(originalType.Module.Assembly)
-            .GetContextForOriginalType(originalType);
+        return (GetNewAssemblyForOriginal(originalType.Module.Assembly) ??
+                 (myAssemblies.TryGetValue("Il2Cppmscorlib", out var result1) ?
+                 result1 :
+                 null))?
+                 .GetContextForOriginalType(originalType) ??
+                 (myAssemblies.TryGetValue("Il2Cppmscorlib", out var result2) ?
+                 result2.GetContextForOriginalType(originalType) :
+                 null);
     }
 
     public TypeRewriteContext? TryGetNewTypeForOriginal(TypeDefinition originalType)
@@ -109,12 +127,18 @@ public class RewriteGlobalContext : IDisposable
             return TypeRewriteContext.TypeSpecifics.ReferenceType;
 
         var fieldTypeContext = GetNewTypeForOriginal(typeRef.Resolve());
-        return fieldTypeContext.ComputedTypeSpecifics;
+        return fieldTypeContext != null ? fieldTypeContext.ComputedTypeSpecifics : TypeRewriteContext.TypeSpecifics.NotComputed;
     }
 
     public AssemblyRewriteContext GetAssemblyByName(string name)
     {
-        return myAssemblies[name];
+        return myAssemblies.TryGetValue(name, out var result1) ?
+                result1 :
+                myAssemblies.TryGetValue("mscorlib", out var result2) ?
+                result2 :
+                myAssemblies.TryGetValue("Il2Cppmscorlib", out var result3) ?
+                result3 :
+                null;
     }
 
     public AssemblyRewriteContext? TryGetAssemblyByName(string name)

--- a/Il2CppInterop.Generator/Il2CppInterop.Generator.csproj
+++ b/Il2CppInterop.Generator/Il2CppInterop.Generator.csproj
@@ -15,10 +15,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Mono.Cecil" Version="0.11.3"/>
+    <PackageReference Include="Mono.Cecil" Version="0.11.5" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Il2CppInterop.Common\Il2CppInterop.Common.csproj"/>
+    <ProjectReference Include="..\Il2CppInterop.Common\Il2CppInterop.Common.csproj" />
   </ItemGroup>
 </Project>

--- a/Il2CppInterop.Generator/Passes/Pass11ComputeTypeSpecifics.cs
+++ b/Il2CppInterop.Generator/Passes/Pass11ComputeTypeSpecifics.cs
@@ -14,6 +14,7 @@ public static class Pass11ComputeTypeSpecifics
 
     private static void ComputeSpecifics(TypeRewriteContext typeContext)
     {
+        if (typeContext == null) return;
         if (typeContext.ComputedTypeSpecifics != TypeRewriteContext.TypeSpecifics.NotComputed) return;
         typeContext.ComputedTypeSpecifics = TypeRewriteContext.TypeSpecifics.Computing;
 
@@ -38,6 +39,7 @@ public static class Pass11ComputeTypeSpecifics
             }
 
             var fieldTypeContext = typeContext.AssemblyContext.GlobalContext.GetNewTypeForOriginal(fieldType.Resolve());
+            if (fieldTypeContext == null) return;
             ComputeSpecifics(fieldTypeContext);
             if (fieldTypeContext.ComputedTypeSpecifics != TypeRewriteContext.TypeSpecifics.BlittableStruct)
             {

--- a/Il2CppInterop.Generator/Runners/DeobfuscationMapGenerator.cs
+++ b/Il2CppInterop.Generator/Runners/DeobfuscationMapGenerator.cs
@@ -151,7 +151,7 @@ internal class DeobfuscationMapGeneratorRunner : IRunner
                 if (cleanType.Item1 == null) return;
 
                 if (!usedNames.TryGetValue(cleanType.Item1.NewType, out var existing) ||
-                    existing.Penalty < cleanType.Item2) 
+                    existing.Penalty < cleanType.Item2)
                     usedNames[cleanType.Item1.NewType] = (typeContext.NewType.GetNamespacePrefix() + "." + typeContext.NewType.Name, cleanType.Item2, typeContext.OriginalType.Namespace != cleanType.Item1.OriginalType.Namespace);
                 else
                     return;

--- a/Il2CppInterop.Generator/Runners/DeobfuscationMapGenerator.cs
+++ b/Il2CppInterop.Generator/Runners/DeobfuscationMapGenerator.cs
@@ -131,9 +131,7 @@ internal class DeobfuscationMapGeneratorRunner : IRunner
                 var matchedField =
                     cleanType.OriginalType.Fields[obfuscatedType.OriginalType.Fields.IndexOf(originalTypeField)];
 
-                writer.WriteLine(obfuscatedType.NewType.GetNamespacePrefix() + "." + obfuscatedType.NewType.Name +
-                                 "::" + Pass22GenerateEnums.GetUnmangledName(originalTypeField) + ";" +
-                                 matchedField.Name + ";0");
+                writer.WriteLine(obfuscatedType.NewType.GetNamespacePrefix() + obfuscatedType.NewType.Name + "::" + Pass22GenerateEnums.GetUnmangledName(originalTypeField) + ";" + matchedField.Name + ";0");
             }
         }
 
@@ -147,16 +145,14 @@ internal class DeobfuscationMapGeneratorRunner : IRunner
 
             void DoType(TypeRewriteContext typeContext, TypeRewriteContext? enclosingType)
             {
-                if (!typeContext.OriginalNameWasObfuscated) return;
+                if (cleanAssembly.TryGetTypeByName(typeContext.NewType.Name) != null) return;
 
                 var cleanType = FindBestMatchType(typeContext, cleanAssembly, enclosingType);
                 if (cleanType.Item1 == null) return;
 
                 if (!usedNames.TryGetValue(cleanType.Item1.NewType, out var existing) ||
-                    existing.Item2 < cleanType.Item2)
-                    usedNames[cleanType.Item1.NewType] = (
-                        typeContext.NewType.GetNamespacePrefix() + "." + typeContext.NewType.Name, cleanType.Item2,
-                        typeContext.OriginalType.Namespace != cleanType.Item1.OriginalType.Namespace);
+                    existing.Penalty < cleanType.Item2) 
+                    usedNames[cleanType.Item1.NewType] = (typeContext.NewType.GetNamespacePrefix() + "." + typeContext.NewType.Name, cleanType.Item2, typeContext.OriginalType.Namespace != cleanType.Item1.OriginalType.Namespace);
                 else
                     return;
 

--- a/Il2CppInterop.Runtime/Injection/Hooks/Class_GetFieldDefaultValue_Hook.cs
+++ b/Il2CppInterop.Runtime/Injection/Hooks/Class_GetFieldDefaultValue_Hook.cs
@@ -49,6 +49,13 @@ namespace Il2CppInterop.Runtime.Injection.Hooks
                 mask = "xxxxxxxxxxxxxxxxxxx",
                 xref = false
             },
+            // Idle Slayer - Unity 2021.3.17 (x64)
+            new MemoryUtils.SignatureDefinition
+            {
+                pattern = "\x40\x53\x48\x83\xEC\x20\x48\x8B\xDA\xE8\x00\x00\x00\x00\x4C\x8B\xC8\x48\x85\xC0",
+                mask = "xxxxxxxxxx????xxxxxx",
+                xref = false
+            },
             // Evony - Unity 2018.4.0 (x86)
             new MemoryUtils.SignatureDefinition
             {


### PR DESCRIPTION
This is more or less a hand merge of my commits to [my branch of unhollower](https://github.com/CamelCaseName/Il2CppAssemblyUnhollower), but since that one is dead I want to contribute them here. I have confirmed it working for House Party, as I have unobfuscated versions available for that game. The current Il2CppInterop produces 1 (one) method mapping in the csv, the old Unhollower just crashed outright. The adjusted versions both produce 762 in the chosen House Party version. This change should not at all affect normal operations of the Interop stuff, it completely resides in the Generator project and fixes an old `//Todo` [set out](https://github.com/knah/Il2CppAssemblyUnhollower/pull/94/files#diff-b2b24df0ecdaf383a12bdcd325b4708e4a2d4a3aa23693b8f0051afb0228219fL187) by knah.

See the changes in the [Unhollower PR](https://github.com/knah/Il2CppAssemblyUnhollower/pull/94) for more info, can also provide example maps on request. 

I'd be happy for anyone to test this change with other obfuscated games. (for house party you can try version 0.21 and version 0.23 for example, somewhere in that timeframe they enabled obfuscation)