### PR TITLE
Fix GenericMethod_GetMethod_Hook on Unity 2020.3.41+

### DIFF
--- a/Il2CppInterop.Runtime/Injection/Hooks/GenericMethod_GetMethod_Hook.cs
+++ b/Il2CppInterop.Runtime/Injection/Hooks/GenericMethod_GetMethod_Hook.cs
@@ -77,9 +77,10 @@ namespace Il2CppInterop.Runtime.Injection.Hooks
                 {
                     genericMethodGetMethod = getVirtualMethodXrefs.Last();
 
-                    var targetTargets = XrefScannerLowLevel.JumpTargets(genericMethodGetMethod).Take(2).ToArray();
-                    if (targetTargets.Length == 1 && UnityVersionHandler.IsMetadataV29OrHigher) // U2021.2.0+, there's additional shim that takes 3 parameters
-                        genericMethodGetMethod = targetTargets[0];
+                    // U2021.2.0+, there's additional shim that takes 3 parameters
+                    // On U2020.3.41+ there is also a shim, which gets inlined with one added in U2021.2.0+ in release builds
+                    if (UnityVersionHandler.HasShimForGetMethod)
+                        genericMethodGetMethod = XrefScannerLowLevel.JumpTargets(genericMethodGetMethod).Take(2).Last();
                 }
             }
 

--- a/Il2CppInterop.Runtime/Runtime/UnityVersionHandler.cs
+++ b/Il2CppInterop.Runtime/Runtime/UnityVersionHandler.cs
@@ -76,6 +76,7 @@ public static class UnityVersionHandler
     }
 
     public static bool HasGetMethodFromReflection { get; private set; }
+    public static bool HasShimForGetMethod { get; private set; }
     public static bool IsMetadataV29OrHigher { get; private set; }
 
     // Version since which extra_arg is set to invoke_multicast, necessitating constructor calls
@@ -84,17 +85,21 @@ public static class UnityVersionHandler
     internal static void RecalculateHandlers()
     {
         Handlers.Clear();
+        var unityVersion = Il2CppInteropRuntime.Instance.UnityVersion;
+
         foreach (var type in InterfacesOfInterest)
             foreach (var valueTuple in VersionedHandlers[type])
             {
-                if (valueTuple.Version > Il2CppInteropRuntime.Instance.UnityVersion) continue;
+                if (valueTuple.Version > unityVersion) continue;
 
                 Handlers[type] = valueTuple.Handler;
                 break;
             }
 
-        HasGetMethodFromReflection = Il2CppInteropRuntime.Instance.UnityVersion > new Version(2018, 1, 0);
-        IsMetadataV29OrHigher = Il2CppInteropRuntime.Instance.UnityVersion >= new Version(2021, 2, 0);
+        HasGetMethodFromReflection = unityVersion > new Version(2018, 1, 0);
+        IsMetadataV29OrHigher = unityVersion >= new Version(2021, 2, 0);
+
+        HasShimForGetMethod = unityVersion >= new Version(2020, 3, 41) || IsMetadataV29OrHigher;
 
         assemblyStructHandler = GetHandler<INativeAssemblyStructHandler>();
         assemblyNameStructHandler = GetHandler<INativeAssemblyNameStructHandler>();


### PR DESCRIPTION
This PR fixes a crash after call to `GenericMethod::GetMethod()` hook. 
This issue appears on Unity version 2020.3.41+, and in some cases in 2021.3.12+, 2022.1.23+ because of this [fix](https://issuetracker.unity3d.com/issues/il2cpp-build-crashes-when-symbols-cannot-be-found)

In these versions `Object::GetVirtualMethod()` calls `GenericMethod::GetGenericVirtualMethod()` instead of `GenericMethod::GetMethod()`
This also has an annoying interaction with shims added in 2021.2.0, where they get inlined together. 

I also removed `targetTargets.Length == 1` check because it seems to be always true, due to early return in `GenericMethod::GetMethod()`  that I noticed. Unfortunately because of this, problems on debug builds could emerge. I don't know if these are important though.

Tested on a custom test game built using 2020.3.46.
@decaprime also confirmed no issues on their beta version of the V Rising Unity 2020.3.46
Also tested on CoreKeeper 2021.3.14, no issues there.

For reference some relevant Unity libil2cpp versions are available here: [link](https://github.com/kremnev8/libil2cpp)