### PR TITLE
Fix issue finding GetFieldDefaultValue on 2021.3.23

### DIFF
--- a/Il2CppInterop.Runtime/Injection/Hooks/Class_GetFieldDefaultValue_Hook.cs
+++ b/Il2CppInterop.Runtime/Injection/Hooks/Class_GetFieldDefaultValue_Hook.cs
@@ -56,6 +56,13 @@ namespace Il2CppInterop.Runtime.Injection.Hooks
                 mask = "xxxxxxxx????xxxxxxx",
                 xref = false
             },
+            // Idle Slayer - Unity 2021.3.23 (x64)
+            new MemoryUtils.SignatureDefinition
+            {
+                pattern = "\x40\x53\x48\x83\xEC\x20\x48\x8B\xDA\xE8\xCC\xCC\xCC\xCC\x4C",
+                mask = "xxxxxxxxxx????x",
+                xref = false
+            }
         };
 
         private static nint FindClassGetFieldDefaultValueXref(bool forceICallMethod = false)
@@ -91,7 +98,11 @@ namespace Il2CppInterop.Runtime.Injection.Hooks
                 var getStaticFieldValue = XrefScannerLowLevel.JumpTargets(getStaticFieldValueAPI).Single();
                 Logger.Instance.LogTrace("Field::StaticGetValue: 0x{GetStaticFieldValueAddress}", getStaticFieldValue.ToInt64().ToString("X2"));
 
-                var getStaticFieldValueInternal = XrefScannerLowLevel.JumpTargets(getStaticFieldValue).Last();
+                var getStaticFieldValueTargets = XrefScannerLowLevel.JumpTargets(getStaticFieldValue).ToArray();
+                if (getStaticFieldValueTargets.Length > 4)
+                    return getStaticFieldValueTargets[^2];
+
+                var getStaticFieldValueInternal = getStaticFieldValueTargets.Last();
                 Logger.Instance.LogTrace("Field::StaticGetValueInternal: 0x{GetStaticFieldValueInternalAddress}", getStaticFieldValueInternal.ToInt64().ToString("X2"));
 
                 var getStaticFieldValueInternalTargets = XrefScannerLowLevel.JumpTargets(getStaticFieldValueInternal).ToArray();


### PR DESCRIPTION
This PR fixes an issue where `Class::GetDefaultFieldValue()` is not found by signature and traversal search returns wrong value because of compiler optimization.
Added a check for such optimization and added the signature from the game where issue occured.
Tested on Idle Slayer Unity 2021.3.23 and Core Keeper Unity 2021.3.14