### PR TITLE
Small fixes

### DIFF
--- a/Il2CppInterop.HarmonySupport/HarmonyBackendComponent.cs
+++ b/Il2CppInterop.HarmonySupport/HarmonyBackendComponent.cs
@@ -1,6 +1,7 @@
 ﻿using HarmonyLib.Public.Patching;
 using Il2CppInterop.Common.Host;
-using Il2CppInterop.Runtime.InteropTypes;
+using Il2CppInterop.Runtime;
+using Il2CppInterop.Runtime.Injection;
 
 namespace Il2CppInterop.HarmonySupport;
 
@@ -21,7 +22,10 @@ internal class HarmonySupportComponent : IHostComponent
 
     private static void TryResolve(object sender, PatchManager.PatcherResolverEventArgs args)
     {
-        if (args.Original.DeclaringType?.IsSubclassOf(typeof(Il2CppObjectBase)) != true)
+        var declaringType = args.Original.DeclaringType;
+        if (declaringType == null) return;
+        if (Il2CppType.From(declaringType, false) == null ||
+            ClassInjector.IsTypeInjectedOnly(declaringType))
         {
             return;
         }

--- a/Il2CppInterop.HarmonySupport/HarmonyBackendComponent.cs
+++ b/Il2CppInterop.HarmonySupport/HarmonyBackendComponent.cs
@@ -25,7 +25,7 @@ internal class HarmonySupportComponent : IHostComponent
         var declaringType = args.Original.DeclaringType;
         if (declaringType == null) return;
         if (Il2CppType.From(declaringType, false) == null ||
-            ClassInjector.IsTypeInjectedOnly(declaringType))
+            ClassInjector.IsManagedTypeInjected(declaringType))
         {
             return;
         }

--- a/Il2CppInterop.Runtime/DelegateSupport.cs
+++ b/Il2CppInterop.Runtime/DelegateSupport.cs
@@ -274,7 +274,7 @@ public static class DelegateSupport
                 throw new ArgumentException(
                     $"Parameter type at {i} has mismatched native type pointers; types: {nativeType.FullName} != {managedType.FullName}");
 
-            if (nativeType.IsByRef && managedType.IsByRef)
+            if (nativeType.IsByRef || managedType.IsByRef)
                 throw new ArgumentException($"Parameter at {i} is passed by reference, this is not supported");
         }
 

--- a/Il2CppInterop.Runtime/DelegateSupport.cs
+++ b/Il2CppInterop.Runtime/DelegateSupport.cs
@@ -37,9 +37,11 @@ public static class DelegateSupport
 
     private static Type CreateDelegateType(MethodInfo managedMethodInner, MethodSignature signature)
     {
-        var newType = ModuleBuilder.DefineType(
-            "Il2CppToManagedDelegate_" + managedMethodInner.DeclaringType.FullName + "_" + signature.GetHashCode() + (signature.HasThis ? "HasThis" : "") +
-            (signature.ConstructedFromNative ? "FromNative" : ""), TypeAttributes.Sealed | TypeAttributes.Public,
+        var typeName = "Il2CppToManagedDelegate_" + managedMethodInner.DeclaringType + "_" + signature.GetHashCode() +
+                       (signature.HasThis ? "HasThis" : "") +
+                       (signature.ConstructedFromNative ? "FromNative" : "");
+
+        var newType = ModuleBuilder.DefineType(typeName, TypeAttributes.Sealed | TypeAttributes.Public,
             typeof(MulticastDelegate));
         newType.SetCustomAttribute(new CustomAttributeBuilder(
             typeof(UnmanagedFunctionPointerAttribute).GetConstructor(new[] { typeof(CallingConvention) })!,
@@ -272,7 +274,7 @@ public static class DelegateSupport
                 throw new ArgumentException(
                     $"Parameter type at {i} has mismatched native type pointers; types: {nativeType.FullName} != {managedType.FullName}");
 
-            if (nativeType.IsByRef || managedType.IsByRef)
+            if (nativeType.IsByRef && managedType.IsByRef)
                 throw new ArgumentException($"Parameter at {i} is passed by reference, this is not supported");
         }
 

--- a/Il2CppInterop.Runtime/Injection/ClassInjector.cs
+++ b/Il2CppInterop.Runtime/Injection/ClassInjector.cs
@@ -128,6 +128,13 @@ public static unsafe partial class ClassInjector
         var currentPointer = Il2CppClassPointerStore.GetNativeClassPointer(type);
         if (currentPointer != IntPtr.Zero)
             return true;
+        if (IsTypeInjectedOnly(type)) return true;
+
+        return false;
+    }
+
+    internal static bool IsTypeInjectedOnly(Type type)
+    {
         lock (InjectedTypes)
         {
             if (InjectedTypes.Contains(type.FullName))

--- a/Il2CppInterop.Runtime/Injection/ClassInjector.cs
+++ b/Il2CppInterop.Runtime/Injection/ClassInjector.cs
@@ -128,12 +128,12 @@ public static unsafe partial class ClassInjector
         var currentPointer = Il2CppClassPointerStore.GetNativeClassPointer(type);
         if (currentPointer != IntPtr.Zero)
             return true;
-        if (IsTypeInjectedOnly(type)) return true;
+        if (IsManagedTypeInjected(type)) return true;
 
         return false;
     }
 
-    internal static bool IsTypeInjectedOnly(Type type)
+    internal static bool IsManagedTypeInjected(Type type)
     {
         lock (InjectedTypes)
         {

--- a/Il2CppInterop.Runtime/Injection/ClassInjector.cs
+++ b/Il2CppInterop.Runtime/Injection/ClassInjector.cs
@@ -305,7 +305,12 @@ public static unsafe partial class ClassInjector
 
         methodPointerArray[0] = ConvertStaticMethod(FinalizeDelegate, "Finalize", classPointer);
         var finalizeMethod = UnityVersionHandler.Wrap(methodPointerArray[0]);
-        if (!type.IsAbstract) methodPointerArray[1] = ConvertStaticMethod(CreateEmptyCtor(type, fieldsToInject), ".ctor", classPointer);
+        var fieldsToInitialize = type
+            .GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+            .Where(IsFieldEligible)
+            .ToArray();
+
+        if (!type.IsAbstract) methodPointerArray[1] = ConvertStaticMethod(CreateEmptyCtor(type, fieldsToInitialize), ".ctor", classPointer);
         var infos = new Dictionary<(string, int, bool), int>(eligibleMethods.Length);
         for (var i = 0; i < eligibleMethods.Length; i++)
         {

--- a/Il2CppInterop.Runtime/InteropTypes/Fields/Il2CppReferenceField.cs
+++ b/Il2CppInterop.Runtime/InteropTypes/Fields/Il2CppReferenceField.cs
@@ -36,7 +36,7 @@ public unsafe class Il2CppReferenceField<TRefObj> where TRefObj : Il2CppObjectBa
 
     public void Set(TRefObj value)
     {
-        *GetPointerToData() = value.Pointer;
+        *GetPointerToData() = value != null ? value.Pointer : IntPtr.Zero;
     }
 
     public static implicit operator TRefObj(Il2CppReferenceField<TRefObj> _this)


### PR DESCRIPTION
This PR combines a number of small fixes:

1. Fix inherited injected fields not being initialized on derived classes
2. Fix errors injecting a type inheriting a abstract type. I'm not entirely sure why this happens, but the `baseVTablePointer[i].method` in my case was not default, even though all of it's fields were null.
3. Fix delegate type names including assembly names. This might cause very long names and if such name becomes too long (I think 1024 characters or more), the runtime will not like it.
4. Fix NRE setting null to `Value` of `Il2CppReferenceField`.
5. Fix Il2Cpp Detour not being applied if target type is a struct. I have tested this change and it does not cause any issues. Patches get called correctly, and `ref MyStruct __instance` injection works correctly.

I have tested these changes on Core Keeper Unity 2021.3.14.