### PR TITLE
Allow static method injection

### DIFF
--- a/Il2CppInterop.Runtime/Injection/ClassInjector.cs
+++ b/Il2CppInterop.Runtime/Injection/ClassInjector.cs
@@ -303,7 +303,7 @@ public static unsafe partial class ClassInjector
         classPointer.InstanceSize = (uint)(fieldOffset + sizeof(InjectedClassData));
         classPointer.ActualSize = classPointer.InstanceSize;
 
-        var eligibleMethods = type.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly).Where(IsMethodEligible).ToArray();
+        var eligibleMethods = type.GetMethods(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly).Where(IsMethodEligible).ToArray();
         var methodsOffset = type.IsAbstract ? 1 : 2; // 1 is the finalizer, 1 is empty ctor
         var methodCount = methodsOffset + eligibleMethods.Length;
 


### PR DESCRIPTION
This PR enables static methods to be injected. This mostly allows to pass such methods to il2cpp delegates, which can be useful in some cases.

My main use of this is for interacting with Burst compiler. It expects us to pass delegates pointing to valid il2cpp methods to consider them for Burst compilation.

I have tested these changes on Core Keeper Unity 2021.3.14.