### PR TITLE
System.AccessViolationException Error Fix

### DIFF
--- a/Il2CppInterop.Runtime/IL2CPP.cs
+++ b/Il2CppInterop.Runtime/IL2CPP.cs
@@ -58,7 +58,7 @@ public static unsafe class IL2CPP
             return IntPtr.Zero;
         }
 
-        var clazz = il2cpp_class_from_name(image, namespaze, className);
+        var clazz = il2cpp_class_from_name(image, Marshal.StringToCoTaskMemUTF8(namespaze), Marshal.StringToCoTaskMemUTF8(className));
         return clazz;
     }
 
@@ -66,7 +66,7 @@ public static unsafe class IL2CPP
     {
         if (clazz == IntPtr.Zero) return IntPtr.Zero;
 
-        var field = il2cpp_class_get_field_from_name(clazz, fieldName);
+        var field = il2cpp_class_get_field_from_name(clazz, Marshal.StringToCoTaskMemUTF8(fieldName));
         if (field == IntPtr.Zero)
             Logger.Instance.LogError(
                 "Field {FieldName} was not found on class {ClassName}", fieldName, Marshal.PtrToStringUTF8(il2cpp_class_get_name(clazz)));
@@ -474,8 +474,7 @@ public static unsafe class IL2CPP
     public static extern IntPtr il2cpp_class_from_il2cpp_type(IntPtr type);
 
     [DllImport("GameAssembly", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
-    public static extern IntPtr il2cpp_class_from_name(IntPtr image, [MarshalAs(UnmanagedType.LPStr)] string namespaze,
-        [MarshalAs(UnmanagedType.LPStr)] string name);
+    public static extern IntPtr il2cpp_class_from_name(IntPtr image, IntPtr namespaze,IntPtr name);
 
     [DllImport("GameAssembly", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
     public static extern IntPtr il2cpp_class_from_system_type(IntPtr type);
@@ -502,8 +501,7 @@ public static unsafe class IL2CPP
     public static extern IntPtr il2cpp_class_get_property_from_name(IntPtr klass, IntPtr name);
 
     [DllImport("GameAssembly", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
-    public static extern IntPtr il2cpp_class_get_field_from_name(IntPtr klass,
-        [MarshalAs(UnmanagedType.LPStr)] string name);
+    public static extern IntPtr il2cpp_class_get_field_from_name(IntPtr klass, IntPtr name);
 
     [DllImport("GameAssembly", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
     public static extern IntPtr il2cpp_class_get_methods(IntPtr klass, ref IntPtr iter);

--- a/Il2CppInterop.Runtime/IL2CPP.cs
+++ b/Il2CppInterop.Runtime/IL2CPP.cs
@@ -58,7 +58,7 @@ public static unsafe class IL2CPP
             return IntPtr.Zero;
         }
 
-        var clazz = il2cpp_class_from_name(image, Marshal.StringToCoTaskMemUTF8(namespaze), Marshal.StringToCoTaskMemUTF8(className));
+        var clazz = il2cpp_class_from_name(image, namespaze, className);
         return clazz;
     }
 
@@ -66,7 +66,7 @@ public static unsafe class IL2CPP
     {
         if (clazz == IntPtr.Zero) return IntPtr.Zero;
 
-        var field = il2cpp_class_get_field_from_name(clazz, Marshal.StringToCoTaskMemUTF8(fieldName));
+        var field = il2cpp_class_get_field_from_name(clazz, fieldName);
         if (field == IntPtr.Zero)
             Logger.Instance.LogError(
                 "Field {FieldName} was not found on class {ClassName}", fieldName, Marshal.PtrToStringUTF8(il2cpp_class_get_name(clazz)));
@@ -474,7 +474,8 @@ public static unsafe class IL2CPP
     public static extern IntPtr il2cpp_class_from_il2cpp_type(IntPtr type);
 
     [DllImport("GameAssembly", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
-    public static extern IntPtr il2cpp_class_from_name(IntPtr image, IntPtr namespaze, IntPtr name);
+    public static extern IntPtr il2cpp_class_from_name(IntPtr image, [MarshalAs(UnmanagedType.LPUTF8Str)] string namespaze,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string name);
 
     [DllImport("GameAssembly", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
     public static extern IntPtr il2cpp_class_from_system_type(IntPtr type);
@@ -501,7 +502,8 @@ public static unsafe class IL2CPP
     public static extern IntPtr il2cpp_class_get_property_from_name(IntPtr klass, IntPtr name);
 
     [DllImport("GameAssembly", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
-    public static extern IntPtr il2cpp_class_get_field_from_name(IntPtr klass, IntPtr name);
+    public static extern IntPtr il2cpp_class_get_field_from_name(IntPtr klass,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string name);
 
     [DllImport("GameAssembly", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
     public static extern IntPtr il2cpp_class_get_methods(IntPtr klass, ref IntPtr iter);

--- a/Il2CppInterop.Runtime/IL2CPP.cs
+++ b/Il2CppInterop.Runtime/IL2CPP.cs
@@ -474,7 +474,7 @@ public static unsafe class IL2CPP
     public static extern IntPtr il2cpp_class_from_il2cpp_type(IntPtr type);
 
     [DllImport("GameAssembly", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
-    public static extern IntPtr il2cpp_class_from_name(IntPtr image, IntPtr namespaze,IntPtr name);
+    public static extern IntPtr il2cpp_class_from_name(IntPtr image, IntPtr namespaze, IntPtr name);
 
     [DllImport("GameAssembly", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
     public static extern IntPtr il2cpp_class_from_system_type(IntPtr type);

--- a/Il2CppInterop.Runtime/Runtime/Il2CppApi.cs
+++ b/Il2CppInterop.Runtime/Runtime/Il2CppApi.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.InteropServices;
 
 namespace Il2CppInterop.Runtime.Runtime;
@@ -198,7 +198,7 @@ internal static unsafe class Il2CppApi
     public static IntPtr il2cpp_class_from_name(IntPtr image, [MarshalAs(UnmanagedType.LPStr)] string namespaze,
         [MarshalAs(UnmanagedType.LPStr)] string name)
     {
-        return IL2CPP.il2cpp_class_from_name(image, namespaze, name);
+        return IL2CPP.il2cpp_class_from_name(image, Marshal.StringToCoTaskMemUTF8(namespaze), Marshal.StringToCoTaskMemUTF8(name));
     }
 
     public static IntPtr il2cpp_class_from_system_type(IntPtr type)
@@ -243,7 +243,7 @@ internal static unsafe class Il2CppApi
 
     public static IntPtr il2cpp_class_get_field_from_name(IntPtr klass, [MarshalAs(UnmanagedType.LPStr)] string name)
     {
-        return IL2CPP.il2cpp_class_get_field_from_name(klass, name);
+        return IL2CPP.il2cpp_class_get_field_from_name(klass, Marshal.StringToCoTaskMemUTF8(name));
     }
 
     public static IntPtr il2cpp_class_get_methods(IntPtr klass, ref IntPtr iter)

--- a/Il2CppInterop.Runtime/Runtime/Il2CppApi.cs
+++ b/Il2CppInterop.Runtime/Runtime/Il2CppApi.cs
@@ -198,7 +198,7 @@ internal static unsafe class Il2CppApi
     public static IntPtr il2cpp_class_from_name(IntPtr image, [MarshalAs(UnmanagedType.LPStr)] string namespaze,
         [MarshalAs(UnmanagedType.LPStr)] string name)
     {
-        return IL2CPP.il2cpp_class_from_name(image, Marshal.StringToCoTaskMemUTF8(namespaze), Marshal.StringToCoTaskMemUTF8(name));
+        return IL2CPP.il2cpp_class_from_name(image, namespaze, name);
     }
 
     public static IntPtr il2cpp_class_from_system_type(IntPtr type)
@@ -243,7 +243,7 @@ internal static unsafe class Il2CppApi
 
     public static IntPtr il2cpp_class_get_field_from_name(IntPtr klass, [MarshalAs(UnmanagedType.LPStr)] string name)
     {
-        return IL2CPP.il2cpp_class_get_field_from_name(klass, Marshal.StringToCoTaskMemUTF8(name));
+        return IL2CPP.il2cpp_class_get_field_from_name(klass, name);
     }
 
     public static IntPtr il2cpp_class_get_methods(IntPtr klass, ref IntPtr iter)


### PR DESCRIPTION
In some games, the obfuscated class and field names appear to be using UTF8, although C# uses UTF-16. I tried using the Encoding class but had no luck, so i did altering the IL2CPP.il2cpp_class_from_name method parameter from IntPtr, String, String to IntPtr, IntPtr, IntPtr and convert the string to IntPtr by calling Marshal.StringToCoTaskMemUTF8 fixed it, i also modify the IL2CPP.il2cpp_class_get_field_from_name from IntPtr, String to IntPtr, IntPtr and convert the field name using the Marshal.The StringToCoTaskMemUTF8 function fixed it.

It fixed the field not found error and the crash when calling obfuscated class methods or fields.