### PR TITLE
Changed to LPUTF8Str to fix Obfuscated Class and Field Problems

### DIFF
--- a/Il2CppInterop.Runtime/IL2CPP.cs
+++ b/Il2CppInterop.Runtime/IL2CPP.cs
@@ -474,8 +474,8 @@ public static unsafe class IL2CPP
     public static extern IntPtr il2cpp_class_from_il2cpp_type(IntPtr type);
 
     [DllImport("GameAssembly", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
-    public static extern IntPtr il2cpp_class_from_name(IntPtr image, [MarshalAs(UnmanagedType.LPStr)] string namespaze,
-        [MarshalAs(UnmanagedType.LPStr)] string name);
+    public static extern IntPtr il2cpp_class_from_name(IntPtr image, [MarshalAs(UnmanagedType.LPUTF8Str)] string namespaze,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string name);
 
     [DllImport("GameAssembly", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
     public static extern IntPtr il2cpp_class_from_system_type(IntPtr type);
@@ -503,7 +503,7 @@ public static unsafe class IL2CPP
 
     [DllImport("GameAssembly", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
     public static extern IntPtr il2cpp_class_get_field_from_name(IntPtr klass,
-        [MarshalAs(UnmanagedType.LPStr)] string name);
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string name);
 
     [DllImport("GameAssembly", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
     public static extern IntPtr il2cpp_class_get_methods(IntPtr klass, ref IntPtr iter);


### PR DESCRIPTION
it fixed the System.AccessViolationException protected memory error in some games