### PR TITLE
Remember injected types and reuse in GetIl2CppTypeFullName

### DIFF
--- a/Il2CppInterop.Runtime/Injection/ClassInjector.cs
+++ b/Il2CppInterop.Runtime/Injection/ClassInjector.cs
@@ -534,7 +534,7 @@ public static unsafe partial class ClassInjector
         if (type.IsValueType ||
             type == typeof(string) ||
             type.IsGenericParameter) return true;
-        if (type.IsByRef) return IsTypeSupported(type.GetElementType());
+        if (type.IsByRef || type.IsPointer) return IsTypeSupported(type.GetElementType());
 
         return typeof(Il2CppObjectBase).IsAssignableFrom(type);
     }
@@ -655,7 +655,7 @@ public static unsafe partial class ClassInjector
                 var parameterType = parameterInfo.ParameterType;
                 if (!parameterType.IsGenericParameter)
                 {
-                    if (parameterType.IsByRef)
+                    if (parameterType.IsByRef || parameterType.IsPointer)
                     {
                         var elementType = parameterType.GetElementType();
                         if (!elementType.IsGenericParameter)
@@ -1083,7 +1083,7 @@ public static unsafe partial class ClassInjector
         if (type.IsValueType && !type.IsEnum)
             return type;
 
-        if (type == typeof(string))
+        if (type == typeof(string) || type == typeof(void*))
             return type;
 
         if (type.IsArray)

--- a/Il2CppInterop.Runtime/Injection/InjectorHelpers.cs
+++ b/Il2CppInterop.Runtime/Injection/InjectorHelpers.cs
@@ -8,16 +8,11 @@ using System.Reflection.Emit;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Il2CppInterop.Common;
-using Il2CppInterop.Common.Extensions;
-using Il2CppInterop.Common.XrefScans;
 using Il2CppInterop.Runtime.Injection.Hooks;
 using Il2CppInterop.Runtime.Runtime;
 using Il2CppInterop.Runtime.Runtime.VersionSpecific.Assembly;
-using Il2CppInterop.Runtime.Runtime.VersionSpecific.Class;
-using Il2CppInterop.Runtime.Runtime.VersionSpecific.FieldInfo;
 using Il2CppInterop.Runtime.Runtime.VersionSpecific.Image;
 using Il2CppInterop.Runtime.Runtime.VersionSpecific.MethodInfo;
-using Il2CppInterop.Runtime.Startup;
 using Microsoft.Extensions.Logging;
 
 namespace Il2CppInterop.Runtime.Injection
@@ -100,6 +95,13 @@ namespace Il2CppInterop.Runtime.Injection
             {
                 s_ClassNameLookup.Add((namespaze, klass, image), typePointer);
             }
+
+            s_TypeLookup[typePointer] = type;
+        }
+
+        internal static bool TryGetType(IntPtr typePointer, out Type type)
+        {
+            return s_TypeLookup.TryGetValue(typePointer, out type);
         }
 
         internal static IntPtr GetIl2CppExport(string name)
@@ -139,6 +141,7 @@ namespace Il2CppInterop.Runtime.Injection
         internal static readonly ConcurrentDictionary<long, IntPtr> s_InjectedClasses = new();
         /// <summary> (namespace, class, image) : class </summary>
         internal static readonly Dictionary<(string _namespace, string _class, IntPtr imagePtr), IntPtr> s_ClassNameLookup = new();
+        internal static readonly Dictionary<IntPtr, Type> s_TypeLookup = new();
 
         #region Class::Init
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]


### PR DESCRIPTION
Injecting a class derived from an existing generic class with a virtual method using the generic type as parameter currently doesn't work.

I had to fix some void* handling for this sample to work as well.

Can be reprodused with this sample plugin:
```
using BepInEx;
using BepInEx.Logging;
using BepInEx.Unity.IL2CPP;
using Il2CppInterop.Runtime.Injection;
using System;
using UnityEngine.InputSystem;

namespace Test;

[BepInPlugin("Test", "Test", "0.0.1")]
public class Plugin : BasePlugin
{
    internal static new ManualLogSource Log;

    public override void Load()
    {
        Log = base.Log;

        ClassInjector.RegisterTypeInIl2Cpp<Haptic>();
        ClassInjector.RegisterTypeInIl2Cpp<HapticControl>();

        Log.LogInfo($"Plugin 'Test' is loaded!");
    }

    public class Haptic : Il2CppSystem.Object
    {
        public Haptic()
            : base(ClassInjector.DerivedConstructorPointer<Haptic>()) { }

        public Haptic(IntPtr pointer)
            : base(pointer) { }

    }

    public class HapticControl : InputControl<Haptic>
    {
        public override unsafe Haptic ReadUnprocessedValueFromState(void* statePtr) => new Haptic();
        public override unsafe Il2CppSystem.Object ReadValueFromBufferAsObject(void* buffer, int bufferSize) => null;
        public override unsafe void ReadValueFromStateIntoBuffer(void* statePtr, void* bufferPtr, int bufferSize) { }
        public override unsafe Il2CppSystem.Object ReadValueFromStateAsObject(void* statePtr) => null;
        public override unsafe void WriteValueFromBufferIntoState(void* bufferPtr, int bufferSize, void* statePtr) { }
        public override unsafe void WriteValueFromObjectIntoState(Il2CppSystem.Object value, void* statePtr) { }
        public override unsafe bool CompareValue(void* firstStatePtr, void* secondStatePtr) => false;
        public override unsafe void WriteValueIntoState(Haptic value, void* statePtr) { }
    }
}
```
Before:
![grafik](https://github.com/BepInEx/Il2CppInterop/assets/3425560/6de33acd-da23-44be-9409-2a100927d063)

After:
![grafik](https://github.com/BepInEx/Il2CppInterop/assets/3425560/b01cd8bd-babf-4903-b33e-9e066ad486ab)
