### PR TITLE
Metadata 27+ Xref crash fix

### DIFF
--- a/Il2CppInterop.Common/Attributes/CachedScanResultsAttribute.cs
+++ b/Il2CppInterop.Common/Attributes/CachedScanResultsAttribute.cs
@@ -5,7 +5,7 @@ public class CachedScanResultsAttribute : Attribute
 {
     // Data for metadata init call
     public long MetadataInitFlagRva;
-    public long MetadataInitTokenRva;
+    public long[] MetadataInitTokenRvas;
     public int RefRangeEnd;
 
     // Methods that call this method

--- a/Il2CppInterop.Common/Attributes/CachedScanResultsAttribute.cs
+++ b/Il2CppInterop.Common/Attributes/CachedScanResultsAttribute.cs
@@ -4,15 +4,15 @@ namespace Il2CppInterop.Common.Attributes;
 public class CachedScanResultsAttribute : Attribute
 {
     // Data for metadata init call
-    public long MetadataInitFlagRva;
-    public long[] MetadataInitTokenRvas;
-    public int RefRangeEnd;
+    public long MetadataInitFlagRva { get; set; }
+    public long[] MetadataInitTokenRvas { get; set; }
+    public int RefRangeEnd { get; set; }
 
     // Methods that call this method
-    public int RefRangeStart;
+    public int RefRangeStart { get; set; }
 
-    public int XrefRangeEnd;
+    public int XrefRangeEnd { get; set; }
 
     // Items that this method calls/uses
-    public int XrefRangeStart;
+    public int XrefRangeStart { get; set; }
 }

--- a/Il2CppInterop.Common/XrefScans/IXrefScannerImpl.cs
+++ b/Il2CppInterop.Common/XrefScans/IXrefScannerImpl.cs
@@ -2,7 +2,7 @@
 
 internal interface IXrefScannerImpl
 {
-    (XrefScanUtil.InitMetadataForMethod, IntPtr)? GetMetadataResolver();
+    IntPtr? GetMetadataResolver();
 
     bool XrefGlobalClassFilter(IntPtr movTarget);
 }

--- a/Il2CppInterop.Common/XrefScans/XrefScanUtil.cs
+++ b/Il2CppInterop.Common/XrefScans/XrefScanUtil.cs
@@ -5,19 +5,28 @@ namespace Il2CppInterop.Common.XrefScans;
 
 internal static class XrefScanUtil
 {
-    private static InitMetadataForMethod ourMetadataInitForMethodDelegate;
+    private static InitMetadataForMethodToken ourMetadataInitForMethodTokenDelegate;
+    private static InitMetadataForMethodPointer ourMetadataInitForMethodPointerDelegate;
     private static IntPtr ourMetadataInitForMethodPointer;
-
-    internal static event Func<(InitMetadataForMethod, IntPtr)> InitRuntimeUtils;
 
     internal static unsafe bool CallMetadataInitForMethod(MethodBase method)
     {
         if (ourMetadataInitForMethodPointer == IntPtr.Zero)
         {
             var res = XrefScannerManager.Impl.GetMetadataResolver();
-            if (res is ({ } m, var p))
+            if (res is IntPtr p)
             {
-                ourMetadataInitForMethodDelegate = m;
+                if (false)
+                {
+                    ourMetadataInitForMethodTokenDelegate =
+                        Marshal.GetDelegateForFunctionPointer<InitMetadataForMethodToken>(p);
+                }
+                else
+                {
+                    ourMetadataInitForMethodPointerDelegate =
+                        Marshal.GetDelegateForFunctionPointer<InitMetadataForMethodPointer>(p);
+                }
+                // ourMetadataInitForMethodPointerDelegate = m;
                 ourMetadataInitForMethodPointer = p;
             }
             else
@@ -31,19 +40,36 @@ internal static class XrefScanUtil
         if (nativeMethodInfoObject == null) return false;
         var nativeMethodInfo = (IntPtr)nativeMethodInfoObject;
         var codeStart = *(IntPtr*)nativeMethodInfo;
-        var firstCall = XrefScannerLowLevel.JumpTargets(codeStart).FirstOrDefault();
-        if (firstCall != ourMetadataInitForMethodPointer || firstCall == IntPtr.Zero) return false;
+        // var firstCall = XrefScannerLowLevel.JumpTargets(codeStart).FirstOrDefault();
+        if (!XrefScannerLowLevel.JumpTargets(codeStart).Any(call => call == ourMetadataInitForMethodPointer)) return false;
 
-        var tokenPointer =
-            XrefScanUtilFinder.FindLastRcxReadAddressBeforeCallTo(codeStart, ourMetadataInitForMethodPointer);
         var initFlagPointer =
             XrefScanUtilFinder.FindByteWriteTargetRightAfterCallTo(codeStart, ourMetadataInitForMethodPointer);
 
-        if (tokenPointer == IntPtr.Zero || initFlagPointer == IntPtr.Zero) return false;
+        // var (initStart, initEnd) = XrefScannerLowLevel.ConditionalBlock(codeStart);
+
+        // if (initStart == IntPtr.Zero || initEnd == IntPtr.Zero) return false;
+
+        // var tokenPointer =
+        //     XrefScanUtilFinder.FindLastRcxReadAddressesBeforeCallTo(initStart, (int)((ulong)initEnd - (ulong)initStart), ourMetadataInitForMethodPointer);
+
+        var tokenPointer =
+            XrefScanUtilFinder.FindLastRcxReadAddressesBeforeCallTo(codeStart, ourMetadataInitForMethodPointer);
+
+        if (!tokenPointer.Any() || initFlagPointer == IntPtr.Zero) return false;
 
         if (Marshal.ReadByte(initFlagPointer) == 0)
         {
-            ourMetadataInitForMethodDelegate(Marshal.ReadInt32(tokenPointer));
+            foreach (var token in tokenPointer) {
+                if (false)
+                {
+                    ourMetadataInitForMethodTokenDelegate(Marshal.ReadInt32(token));
+                }
+                else
+                {
+                    ourMetadataInitForMethodPointerDelegate(token);
+                }
+            }
             Marshal.WriteByte(initFlagPointer, 1);
         }
 
@@ -51,5 +77,8 @@ internal static class XrefScanUtil
     }
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    internal delegate void InitMetadataForMethod(int metadataUsageToken);
+    internal delegate void InitMetadataForMethodToken(int metadataUsageToken);
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    internal delegate void InitMetadataForMethodPointer(IntPtr metadataUsageToken);
 }

--- a/Il2CppInterop.Common/XrefScans/XrefScanner.cs
+++ b/Il2CppInterop.Common/XrefScans/XrefScanner.cs
@@ -70,10 +70,10 @@ public static class XrefScanner
             if (instruction.FlowControl == FlowControl.Return)
                 yield break;
 
-            if (instruction.Mnemonic == Mnemonic.Int || instruction.Mnemonic == Mnemonic.Int1)
+            if (instruction.Mnemonic is Mnemonic.Int or Mnemonic.Int1 or Mnemonic.Int3)
                 yield break;
 
-            if (instruction.Mnemonic == Mnemonic.Call || instruction.Mnemonic == Mnemonic.Jmp)
+            if (instruction.Mnemonic is Mnemonic.Call or Mnemonic.Jmp)
             {
                 var targetAddress = ExtractTargetAddress(instruction);
                 if (targetAddress != 0)

--- a/Il2CppInterop.Generator/Contexts/MethodRewriteContext.cs
+++ b/Il2CppInterop.Generator/Contexts/MethodRewriteContext.cs
@@ -37,7 +37,7 @@ public class MethodRewriteContext
     public readonly List<XrefInstance> XrefScanResults = new();
 
     public long MetadataInitFlagRva;
-    public long MetadataInitTokenRva;
+    public long[] MetadataInitTokenRvas;
 
     public MethodRewriteContext(TypeRewriteContext declaringType, MethodDefinition originalMethod)
     {

--- a/Il2CppInterop.Generator/Passes/Pass16ScanMethodRefs.cs
+++ b/Il2CppInterop.Generator/Passes/Pass16ScanMethodRefs.cs
@@ -60,7 +60,7 @@ public static class Pass16ScanMethodRefs
                 {
                     var pair = XrefScanMetadataGenerationUtil.FindMetadataInitForMethod(originalTypeMethod, gameAssemblyPtr);
                     originalTypeMethod.MetadataInitFlagRva = pair.FlagRva;
-                    originalTypeMethod.MetadataInitTokenRva = pair.TokenRva;
+                    originalTypeMethod.MetadataInitTokenRvas = pair.TokenRvas;
                 }
 
                 var nextMethodStart = context.MethodStartAddresses.BinarySearch(address + 1);

--- a/Il2CppInterop.Generator/Passes/Pass89GenerateMethodXrefCache.cs
+++ b/Il2CppInterop.Generator/Passes/Pass89GenerateMethodXrefCache.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-using System.IO;
 using System.Text;
 using Il2CppInterop.Common.Attributes;
 using Il2CppInterop.Common.Maps;
@@ -7,6 +5,7 @@ using Il2CppInterop.Generator.Contexts;
 using Il2CppInterop.Generator.Extensions;
 using Il2CppInterop.Generator.Utils;
 using Mono.Cecil;
+using Mono.Cecil.Rocks;
 
 namespace Il2CppInterop.Generator.Passes;
 
@@ -37,7 +36,7 @@ public static class Pass89GenerateMethodXrefCache
                         methodRewriteContext.NewMethod.CustomAttributes.Add(
                             new CustomAttribute(imports.CachedScanResultsAttributector.Value)
                             {
-                                Fields =
+                                Properties =
                                 {
                                 new CustomAttributeNamedArgument(
                                     nameof(CachedScanResultsAttribute.RefRangeStart),
@@ -52,8 +51,11 @@ public static class Pass89GenerateMethodXrefCache
                                     nameof(CachedScanResultsAttribute.XrefRangeEnd),
                                     new CustomAttributeArgument(imports.Module.Int(), attribute.RefRangeEnd)),
                                 new CustomAttributeNamedArgument(
-                                    nameof(CachedScanResultsAttribute.MetadataInitTokenRva),
-                                    new CustomAttributeArgument(imports.Module.Long(), attribute.MetadataInitTokenRva)),
+                                    nameof(CachedScanResultsAttribute.MetadataInitTokenRvas),
+                                    new CustomAttributeArgument(imports.Module.Long().MakeArrayType(),
+                                        attribute.MetadataInitTokenRvas
+                                            .Select(rva => new CustomAttributeArgument(imports.Module.Long(), rva))
+                                            .ToArray())),
                                 new CustomAttributeNamedArgument(
                                     nameof(CachedScanResultsAttribute.MetadataInitFlagRva),
                                     new CustomAttributeArgument(imports.Module.Long(), attribute.MetadataInitFlagRva))
@@ -87,7 +89,7 @@ public static class Pass89GenerateMethodXrefCache
                         methodRewriteContext.NewMethod.CustomAttributes.Add(
                             new CustomAttribute(imports.CachedScanResultsAttributector.Value)
                             {
-                                Fields =
+                                Properties =
                                 {
                                 new CustomAttributeNamedArgument(
                                     nameof(CachedScanResultsAttribute.RefRangeStart),
@@ -102,9 +104,11 @@ public static class Pass89GenerateMethodXrefCache
                                     nameof(CachedScanResultsAttribute.XrefRangeEnd),
                                     new CustomAttributeArgument(imports.Module.Int(), xrefEnd)),
                                 new CustomAttributeNamedArgument(
-                                    nameof(CachedScanResultsAttribute.MetadataInitTokenRva),
-                                    new CustomAttributeArgument(imports.Module.Long(),
-                                        methodRewriteContext.MetadataInitTokenRva)),
+                                    nameof(CachedScanResultsAttribute.MetadataInitTokenRvas),
+                                    new CustomAttributeArgument(imports.Module.Long().MakeArrayType(),
+                                        methodRewriteContext.MetadataInitTokenRvas
+                                            .Select(rva => new CustomAttributeArgument(imports.Module.Long(), rva))
+                                            .ToArray())),
                                 new CustomAttributeNamedArgument(
                                     nameof(CachedScanResultsAttribute.MetadataInitFlagRva),
                                     new CustomAttributeArgument(imports.Module.Long(),
@@ -119,7 +123,7 @@ public static class Pass89GenerateMethodXrefCache
                             XrefRangeStart = xrefStart,
                             XrefRangeEnd = xrefEnd,
                             MetadataInitFlagRva = methodRewriteContext.MetadataInitFlagRva,
-                            MetadataInitTokenRva = methodRewriteContext.MetadataInitTokenRva
+                            MetadataInitTokenRvas = methodRewriteContext.MetadataInitTokenRvas
                         };
                     }
                 }

--- a/Il2CppInterop.Generator/XrefScans/XrefScanImpl.cs
+++ b/Il2CppInterop.Generator/XrefScans/XrefScanImpl.cs
@@ -5,7 +5,7 @@ namespace Il2CppInterop.Generator.XrefScans;
 
 internal class XrefScanImpl : IXrefScannerImpl
 {
-    public (XrefScanUtil.InitMetadataForMethod, IntPtr)? GetMetadataResolver()
+    public IntPtr? GetMetadataResolver()
     {
         return null;
     }

--- a/Il2CppInterop.Runtime/IL2CPP.cs
+++ b/Il2CppInterop.Runtime/IL2CPP.cs
@@ -34,7 +34,7 @@ public static unsafe class IL2CPP
         for (var i = 0; i < assembliesCount; i++)
         {
             var image = il2cpp_assembly_get_image(assemblies[i]);
-            var name = Marshal.PtrToStringAnsi(il2cpp_image_get_name(image));
+            var name = il2cpp_image_get_name(image);
             ourImagesMap[name] = image;
         }
     }
@@ -69,7 +69,7 @@ public static unsafe class IL2CPP
         var field = il2cpp_class_get_field_from_name(clazz, fieldName);
         if (field == IntPtr.Zero)
             Logger.Instance.LogError(
-                "Field {FieldName} was not found on class {ClassName}", fieldName, Marshal.PtrToStringUTF8(il2cpp_class_get_name(clazz)));
+                "Field {FieldName} was not found on class {ClassName}", fieldName, il2cpp_class_get_name(clazz));
         return field;
     }
 
@@ -84,7 +84,7 @@ public static unsafe class IL2CPP
             if (il2cpp_method_get_token(method) == token)
                 return method;
 
-        var className = Marshal.PtrToStringAnsi(il2cpp_class_get_name(clazz));
+        var className = il2cpp_class_get_name(clazz);
         Logger.Instance.LogTrace("Unable to find method {ClassName}::{Token}", className, token);
 
         return NativeStructUtils.GetMethodInfoForMissingMethod(className + "::" + token);
@@ -110,7 +110,7 @@ public static unsafe class IL2CPP
         IntPtr method;
         while ((method = il2cpp_class_get_methods(clazz, ref iter)) != IntPtr.Zero)
         {
-            if (Marshal.PtrToStringAnsi(il2cpp_method_get_name(method)) != methodName)
+            if (il2cpp_method_get_name(method) != methodName)
                 continue;
 
             if (il2cpp_method_get_param_count(method) != argTypes.Length)
@@ -120,7 +120,7 @@ public static unsafe class IL2CPP
                 continue;
 
             var returnType = il2cpp_method_get_return_type(method);
-            var returnTypeNameActual = Marshal.PtrToStringAnsi(il2cpp_type_get_name(returnType));
+            var returnTypeNameActual = il2cpp_type_get_name(returnType);
             if (returnTypeNameActual != returnTypeName)
                 continue;
 
@@ -131,7 +131,7 @@ public static unsafe class IL2CPP
             for (var i = 0; i < argTypes.Length; i++)
             {
                 var paramType = il2cpp_method_get_param(method, (uint)i);
-                var typeName = Marshal.PtrToStringAnsi(il2cpp_type_get_name(paramType));
+                var typeName = il2cpp_type_get_name(paramType);
                 if (typeName != argTypes[i])
                 {
                     badType = true;
@@ -144,19 +144,19 @@ public static unsafe class IL2CPP
             return method;
         }
 
-        var className = Marshal.PtrToStringAnsi(il2cpp_class_get_name(clazz));
+        var className = il2cpp_class_get_name(clazz);
 
         if (methodsSeen == 1)
         {
             Logger.Instance.LogTrace(
                 "Method {ClassName}::{MethodName} was stubbed with a random matching method of the same name", className, methodName);
             Logger.Instance.LogTrace(
-                "Stubby return type/target: {LastMethod} / {ReturnTypeName}", Marshal.PtrToStringUTF8(il2cpp_type_get_name(il2cpp_method_get_return_type(lastMethod))), returnTypeName);
+                "Stubby return type/target: {LastMethod} / {ReturnTypeName}", il2cpp_type_get_name(il2cpp_method_get_return_type(lastMethod)), returnTypeName);
             Logger.Instance.LogTrace("Stubby parameter types/targets follow:");
             for (var i = 0; i < argTypes.Length; i++)
             {
                 var paramType = il2cpp_method_get_param(lastMethod, (uint)i);
-                var typeName = Marshal.PtrToStringAnsi(il2cpp_type_get_name(paramType));
+                var typeName = il2cpp_type_get_name(paramType);
                 Logger.Instance.LogTrace("    {TypeName} / {ArgType}", typeName, argTypes[i]);
             }
 
@@ -171,17 +171,17 @@ public static unsafe class IL2CPP
         iter = IntPtr.Zero;
         while ((method = il2cpp_class_get_methods(clazz, ref iter)) != IntPtr.Zero)
         {
-            if (Marshal.PtrToStringAnsi(il2cpp_method_get_name(method)) != methodName)
+            if (il2cpp_method_get_name(method) != methodName)
                 continue;
 
             var nParams = il2cpp_method_get_param_count(method);
             Logger.Instance.LogTrace("Method starts");
             Logger.Instance.LogTrace(
-                "     return {MethodTypeName}", Marshal.PtrToStringUTF8(il2cpp_type_get_name(il2cpp_method_get_return_type(method))));
+                "     return {MethodTypeName}", il2cpp_type_get_name(il2cpp_method_get_return_type(method)));
             for (var i = 0; i < nParams; i++)
             {
                 var paramType = il2cpp_method_get_param(method, (uint)i);
-                var typeName = Marshal.PtrToStringAnsi(il2cpp_type_get_name(paramType));
+                var typeName = il2cpp_type_get_name(paramType);
                 Logger.Instance.LogTrace("    {TypeName}", typeName);
             }
 
@@ -236,11 +236,11 @@ public static unsafe class IL2CPP
         }
 
         while ((nestedTypePtr = il2cpp_class_get_nested_types(enclosingType, ref iter)) != IntPtr.Zero)
-            if (Marshal.PtrToStringUTF8(il2cpp_class_get_name(nestedTypePtr)) == nestedTypeName)
+            if (il2cpp_class_get_name(nestedTypePtr) == nestedTypeName)
                 return nestedTypePtr;
 
         Logger.Instance.LogError(
-            "Nested type {NestedTypeName} on {EnclosingTypeName} not found!", nestedTypeName, Marshal.PtrToStringUTF8(il2cpp_class_get_name(enclosingType)));
+            "Nested type {NestedTypeName} on {EnclosingTypeName} not found!", nestedTypeName, il2cpp_class_get_name(enclosingType));
 
         return IntPtr.Zero;
     }
@@ -510,13 +510,15 @@ public static unsafe class IL2CPP
 
     [DllImport("GameAssembly", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
     public static extern IntPtr il2cpp_class_get_method_from_name(IntPtr klass,
-        [MarshalAs(UnmanagedType.LPStr)] string name, int argsCount);
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string name, int argsCount);
 
     [DllImport("GameAssembly", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
-    public static extern IntPtr il2cpp_class_get_name(IntPtr klass);
+    [return: MarshalAs(UnmanagedType.LPUTF8Str)]
+    public static extern string il2cpp_class_get_name(IntPtr klass);
 
     [DllImport("GameAssembly", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
-    public static extern IntPtr il2cpp_class_get_namespace(IntPtr klass);
+    [return: MarshalAs(UnmanagedType.LPUTF8Str)]
+    public static extern string il2cpp_class_get_namespace(IntPtr klass);
 
     [DllImport("GameAssembly", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
     public static extern IntPtr il2cpp_class_get_parent(IntPtr klass);
@@ -580,7 +582,8 @@ public static unsafe class IL2CPP
     public static extern IntPtr il2cpp_class_get_image(IntPtr klass);
 
     [DllImport("GameAssembly", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
-    public static extern IntPtr il2cpp_class_get_assemblyname(IntPtr klass);
+    [return: MarshalAs(UnmanagedType.LPUTF8Str)]
+    public static extern string il2cpp_class_get_assemblyname(IntPtr klass);
 
     [DllImport("GameAssembly", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
     public static extern int il2cpp_class_get_rank(IntPtr klass);
@@ -626,7 +629,8 @@ public static unsafe class IL2CPP
     public static extern int il2cpp_field_get_flags(IntPtr field);
 
     [DllImport("GameAssembly", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
-    public static extern IntPtr il2cpp_field_get_name(IntPtr field);
+    [return: MarshalAs(UnmanagedType.LPUTF8Str)]
+    public static extern string il2cpp_field_get_name(IntPtr field);
 
     [DllImport("GameAssembly", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
     public static extern IntPtr il2cpp_field_get_parent(IntPtr field);
@@ -717,7 +721,8 @@ public static unsafe class IL2CPP
     public static extern IntPtr il2cpp_method_get_declaring_type(IntPtr method);
 
     [DllImport("GameAssembly", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
-    public static extern IntPtr il2cpp_method_get_name(IntPtr method);
+    [return: MarshalAs(UnmanagedType.LPUTF8Str)]
+    public static extern string il2cpp_method_get_name(IntPtr method);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static IntPtr il2cpp_method_get_from_reflection(IntPtr method)
@@ -765,7 +770,8 @@ public static unsafe class IL2CPP
     public static extern uint il2cpp_method_get_token(IntPtr method);
 
     [DllImport("GameAssembly", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
-    public static extern IntPtr il2cpp_method_get_param_name(IntPtr method, uint index);
+    [return: MarshalAs(UnmanagedType.LPUTF8Str)]
+    public static extern string il2cpp_method_get_param_name(IntPtr method, uint index);
 
     [DllImport("GameAssembly", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
     public static extern void il2cpp_profiler_install(IntPtr prof, IntPtr shutdown_callback);
@@ -797,7 +803,8 @@ public static unsafe class IL2CPP
     public static extern IntPtr il2cpp_property_get_set_method(IntPtr prop);
 
     [DllImport("GameAssembly", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
-    public static extern IntPtr il2cpp_property_get_name(IntPtr prop);
+    [return: MarshalAs(UnmanagedType.LPUTF8Str)]
+    public static extern string il2cpp_property_get_name(IntPtr prop);
 
     [DllImport("GameAssembly", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
     public static extern IntPtr il2cpp_property_get_parent(IntPtr prop);
@@ -940,7 +947,8 @@ public static unsafe class IL2CPP
     public static extern IntPtr il2cpp_type_get_class_or_element_class(IntPtr type);
 
     [DllImport("GameAssembly", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
-    public static extern IntPtr il2cpp_type_get_name(IntPtr type);
+    [return: MarshalAs(UnmanagedType.LPUTF8Str)]
+    public static extern string il2cpp_type_get_name(IntPtr type);
 
     [DllImport("GameAssembly", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
     [return: MarshalAs(UnmanagedType.I1)]
@@ -960,10 +968,12 @@ public static unsafe class IL2CPP
     public static extern IntPtr il2cpp_image_get_assembly(IntPtr image);
 
     [DllImport("GameAssembly", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
-    public static extern IntPtr il2cpp_image_get_name(IntPtr image);
+    [return: MarshalAs(UnmanagedType.LPUTF8Str)]
+    public static extern string il2cpp_image_get_name(IntPtr image);
 
     [DllImport("GameAssembly", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
-    public static extern IntPtr il2cpp_image_get_filename(IntPtr image);
+    [return: MarshalAs(UnmanagedType.LPUTF8Str)]
+    public static extern string il2cpp_image_get_filename(IntPtr image);
 
     [DllImport("GameAssembly", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
     public static extern IntPtr il2cpp_image_get_entry_point(IntPtr image);

--- a/Il2CppInterop.Runtime/IL2CPP.cs
+++ b/Il2CppInterop.Runtime/IL2CPP.cs
@@ -236,7 +236,7 @@ public static unsafe class IL2CPP
         }
 
         while ((nestedTypePtr = il2cpp_class_get_nested_types(enclosingType, ref iter)) != IntPtr.Zero)
-            if (Marshal.PtrToStringAnsi(il2cpp_class_get_name(nestedTypePtr)) == nestedTypeName)
+            if (Marshal.PtrToStringUTF8(il2cpp_class_get_name(nestedTypePtr)) == nestedTypeName)
                 return nestedTypePtr;
 
         Logger.Instance.LogError(

--- a/Il2CppInterop.Runtime/Injection/ClassInjector.Debug.cs
+++ b/Il2CppInterop.Runtime/Injection/ClassInjector.Debug.cs
@@ -23,7 +23,7 @@ public unsafe partial class ClassInjector
     private static string ToString(Il2CppTypeStruct* il2CppType)
     {
         if (il2CppType == default) return "null";
-        return Marshal.PtrToStringAnsi(IL2CPP.il2cpp_type_get_name((IntPtr)il2CppType));
+        return IL2CPP.il2cpp_type_get_name((IntPtr)il2CppType);
     }
 
     public static void Dump(Il2CppClass* il2CppClass)

--- a/Il2CppInterop.Runtime/InteropTypes/Il2CppObjectBase.cs
+++ b/Il2CppInterop.Runtime/InteropTypes/Il2CppObjectBase.cs
@@ -59,7 +59,7 @@ public class Il2CppObjectBase
     public T Cast<T>() where T : Il2CppObjectBase
     {
         return TryCast<T>() ?? throw new InvalidCastException(
-            $"Can't cast object of type {Marshal.PtrToStringAnsi(IL2CPP.il2cpp_class_get_name(IL2CPP.il2cpp_object_get_class(Pointer)))} to type {typeof(T)}");
+            $"Can't cast object of type {IL2CPP.il2cpp_class_get_name(IL2CPP.il2cpp_object_get_class(Pointer))} to type {typeof(T)}");
     }
 
     internal static unsafe T UnboxUnsafe<T>(IntPtr pointer)
@@ -71,7 +71,7 @@ public class Il2CppObjectBase
         var ownClass = IL2CPP.il2cpp_object_get_class(pointer);
         if (!IL2CPP.il2cpp_class_is_assignable_from(nestedTypeClassPointer, ownClass))
             throw new InvalidCastException(
-                $"Can't cast object of type {Marshal.PtrToStringAnsi(IL2CPP.il2cpp_class_get_name(ownClass))} to type {typeof(T)}");
+                $"Can't cast object of type {IL2CPP.il2cpp_class_get_name(ownClass)} to type {typeof(T)}");
 
         return Unsafe.AsRef<T>(IL2CPP.il2cpp_object_unbox(pointer).ToPointer());
     }

--- a/Il2CppInterop.Runtime/Runtime/Il2CppApi.cs
+++ b/Il2CppInterop.Runtime/Runtime/Il2CppApi.cs
@@ -257,12 +257,12 @@ internal static unsafe class Il2CppApi
         return IL2CPP.il2cpp_class_get_method_from_name(klass, name, argsCount);
     }
 
-    public static IntPtr il2cpp_class_get_name(IntPtr klass)
+    public static string il2cpp_class_get_name(IntPtr klass)
     {
         return IL2CPP.il2cpp_class_get_name(klass);
     }
 
-    public static IntPtr il2cpp_class_get_namespace(IntPtr klass)
+    public static string il2cpp_class_get_namespace(IntPtr klass)
     {
         return IL2CPP.il2cpp_class_get_namespace(klass);
     }
@@ -357,7 +357,7 @@ internal static unsafe class Il2CppApi
         return IL2CPP.il2cpp_class_get_image(klass);
     }
 
-    public static IntPtr il2cpp_class_get_assemblyname(IntPtr klass)
+    public static string il2cpp_class_get_assemblyname(IntPtr klass)
     {
         return IL2CPP.il2cpp_class_get_assemblyname(klass);
     }
@@ -629,12 +629,12 @@ internal static unsafe class Il2CppApi
         return IL2CPP.il2cpp_image_get_assembly(image);
     }
 
-    public static IntPtr il2cpp_image_get_name(IntPtr image)
+    public static string il2cpp_image_get_name(IntPtr image)
     {
         return IL2CPP.il2cpp_image_get_name(image);
     }
 
-    public static IntPtr il2cpp_image_get_filename(IntPtr image)
+    public static string il2cpp_image_get_filename(IntPtr image)
     {
         return IL2CPP.il2cpp_image_get_filename(image);
     }
@@ -742,7 +742,7 @@ internal static unsafe class Il2CppApi
         return UnityVersionHandler.Wrap((Il2CppMethodInfo*)method).Token;
     }
 
-    public static IntPtr il2cpp_method_get_param_name(IntPtr method, uint index)
+    public static string il2cpp_method_get_param_name(IntPtr method, uint index)
     {
         return IL2CPP.il2cpp_method_get_param_name(method, index);
     }
@@ -1050,7 +1050,7 @@ internal static unsafe class Il2CppApi
         return IL2CPP.il2cpp_type_get_class_or_element_class(type);
     }
 
-    public static IntPtr il2cpp_type_get_name(IntPtr type)
+    public static string il2cpp_type_get_name(IntPtr type)
     {
         return IL2CPP.il2cpp_type_get_name(type);
     }

--- a/Il2CppInterop.Runtime/Runtime/UnityVersionHandler.cs
+++ b/Il2CppInterop.Runtime/Runtime/UnityVersionHandler.cs
@@ -78,6 +78,7 @@ public static class UnityVersionHandler
     public static bool HasGetMethodFromReflection { get; private set; }
     public static bool HasShimForGetMethod { get; private set; }
     public static bool IsMetadataV29OrHigher { get; private set; }
+    public static bool HasTokenBasedMethodInitializer { get; private set; }
 
     // Version since which extra_arg is set to invoke_multicast, necessitating constructor calls
     public static bool MustUseDelegateConstructor => IsMetadataV29OrHigher;
@@ -100,6 +101,7 @@ public static class UnityVersionHandler
         IsMetadataV29OrHigher = unityVersion >= new Version(2021, 2, 0);
 
         HasShimForGetMethod = unityVersion >= new Version(2020, 3, 41) || IsMetadataV29OrHigher;
+        HasTokenBasedMethodInitializer = unityVersion < new Version(2020, 2, 0);
 
         assemblyStructHandler = GetHandler<INativeAssemblyStructHandler>();
         assemblyNameStructHandler = GetHandler<INativeAssemblyNameStructHandler>();


### PR DESCRIPTION
On previous versions, one call per method instantiated all globals used.
Now there is one call per global. Instead of a method-handle, the pointers are passed directly.
With method inlining, multiple of these blocks are added into one method

This bug would manifest as hard crashes during xref on methods that weren't fully initialized by the runtime.

TODO: Only one of the flags is set and we might check the wrong one

I got distracted and never properly implemented this. I hope these patches can help you.