### PR TITLE
Fix for InjectorHelper crashing the process when running on MacOS

### DIFF
--- a/Il2CppInterop.Runtime/Injection/InjectorHelpers.cs
+++ b/Il2CppInterop.Runtime/Injection/InjectorHelpers.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime.InteropServices;
+using System.IO;
 using System.Threading;
 using Il2CppInterop.Common;
 using Il2CppInterop.Common.Extensions;
@@ -29,7 +30,14 @@ namespace Il2CppInterop.Runtime.Injection
         internal static INativeImageStruct InjectedImage;
         internal static ProcessModule Il2CppModule = Process.GetCurrentProcess()
             .Modules.OfType<ProcessModule>()
-            .Single((x) => x.ModuleName is "GameAssembly.dll" or "GameAssembly.so" or "UserAssembly.dll");
+            .Single((x) =>
+            {
+                // Get assembly name without extension
+                string name = Path.GetFileNameWithoutExtension(x.ModuleName);
+
+                // Check if it matches
+                return name == "GameAssembly" || name == "UserAssembly";
+            });
 
         internal static IntPtr Il2CppHandle = NativeLibrary.Load("GameAssembly", typeof(InjectorHelpers).Assembly, null);
 

--- a/Il2CppInterop.Runtime/Injection/InjectorHelpers.cs
+++ b/Il2CppInterop.Runtime/Injection/InjectorHelpers.cs
@@ -2,11 +2,11 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime.InteropServices;
-using System.IO;
 using System.Threading;
 using Il2CppInterop.Common;
 using Il2CppInterop.Common.Extensions;


### PR DESCRIPTION
While working with MacOS modding, InjectorHelper crashed the process as MacOS uses `GameAssembly.dylib` instead of `GameAsssembly.dll` or `GameAssembly.so` as the class expected

This drafted patch gets around the issue

This is one of my first PRs to a OSS project, feedback is appreciated 