### PR TITLE
Account for type name when renaming properties and methods from the deobf map

### DIFF
--- a/Il2CppInterop.Generator/Contexts/MethodRewriteContext.cs
+++ b/Il2CppInterop.Generator/Contexts/MethodRewriteContext.cs
@@ -242,9 +242,18 @@ public class MethodRewriteContext
     {
         var unmangleMethodNameWithSignature = ProduceMethodSignatureBase() + "_" + DeclaringType.Methods
             .Where(ParameterSignatureMatchesThis).TakeWhile(it => it != this).Count();
+
         if (DeclaringType.AssemblyContext.GlobalContext.Options.RenameMap.TryGetValue(
+                DeclaringType.NewType.GetNamespacePrefix() + "." + DeclaringType.NewType.Name + "::" + unmangleMethodNameWithSignature, out var newNameByType))
+        {
+            unmangleMethodNameWithSignature = newNameByType;
+        }
+        else if (DeclaringType.AssemblyContext.GlobalContext.Options.RenameMap.TryGetValue(
                 DeclaringType.NewType.GetNamespacePrefix() + "::" + unmangleMethodNameWithSignature, out var newName))
+        {
             unmangleMethodNameWithSignature = newName;
+        }
+
         return unmangleMethodNameWithSignature;
     }
 

--- a/Il2CppInterop.Generator/Passes/Pass70GenerateProperties.cs
+++ b/Il2CppInterop.Generator/Passes/Pass70GenerateProperties.cs
@@ -85,8 +85,16 @@ public static class Pass70GenerateProperties
         var unmanglePropertyName = baseName + "_" + index;
 
         if (assemblyContext.GlobalContext.Options.RenameMap.TryGetValue(
-                declaringType.GetNamespacePrefix() + "." + declaringType.Name + "::" + unmanglePropertyName, out var newName))
+                declaringType.GetNamespacePrefix() + "." + declaringType.Name + "::" + unmanglePropertyName, out var newNameByType))
+        {
+            unmanglePropertyName = newNameByType;
+        }
+        else if (assemblyContext.GlobalContext.Options.RenameMap.TryGetValue(
+                       declaringType.GetNamespacePrefix() + "::" + unmanglePropertyName, out var newName))
+        {
             unmanglePropertyName = newName;
+        }
+
 
         return unmanglePropertyName;
     }

--- a/Il2CppInterop.Generator/Passes/Pass70GenerateProperties.cs
+++ b/Il2CppInterop.Generator/Passes/Pass70GenerateProperties.cs
@@ -85,7 +85,7 @@ public static class Pass70GenerateProperties
         var unmanglePropertyName = baseName + "_" + index;
 
         if (assemblyContext.GlobalContext.Options.RenameMap.TryGetValue(
-                declaringType.GetNamespacePrefix() + "::" + unmanglePropertyName, out var newName))
+                declaringType.GetNamespacePrefix() + "." + declaringType.Name + "::" + unmanglePropertyName, out var newName))
             unmanglePropertyName = newName;
 
         return unmanglePropertyName;


### PR DESCRIPTION
This means that when there are two types in the same namespace that have properties or methods with the same name, trying to rename them will work as intended (like fields).

~~This change is 'breaking', though considering this issue meant property renaming was completely broken makes me think that nobody will be impacted.~~ Now checking for both