### PR TITLE
Ubisoft+ IL2CPP Support. They bundle two different EXE/GameAssembly files for retail and subscription versions. 

### DIFF
--- a/Il2CppInterop.Common/XrefScans/XrefScanMethodDb.cs
+++ b/Il2CppInterop.Common/XrefScans/XrefScanMethodDb.cs
@@ -21,7 +21,7 @@ public static class XrefScanMethodDb
         XrefScanCache = new MethodXrefScanCache(GeneratedDatabasesUtil.GetDatabasePath(MethodXrefScanCache.FileName));
 
         foreach (ProcessModule module in Process.GetCurrentProcess().Modules)
-            if (module.ModuleName == "GameAssembly.dll")
+            if (module.ModuleName is "GameAssembly.dll" or "GameAssembly_plus.dll")
             {
                 GameAssemblyBase = (long)module.BaseAddress;
                 break;

--- a/Il2CppInterop.Runtime/Injection/InjectorHelpers.cs
+++ b/Il2CppInterop.Runtime/Injection/InjectorHelpers.cs
@@ -19,7 +19,15 @@ namespace Il2CppInterop.Runtime.Injection
 {
     internal static unsafe class InjectorHelpers
     {
-        private static readonly string[] s_assemblies = {"GameAssembly.dll", "GameAssembly_plus.dll", "GameAssembly.so", "GameAssembly_plus.so", "UserAssembly.dll", "UserAssembly_plus.dll"};
+        private static readonly string[] s_assemblies =
+        {
+            "GameAssembly.dll",
+            "GameAssembly_plus.dll",
+            "GameAssembly.so",
+            "GameAssembly_plus.so",
+            "UserAssembly.dll",
+            "UserAssembly_plus.dll"
+        };
 
         internal static Assembly Il2CppMscorlib = typeof(Il2CppSystem.Type).Assembly;
         internal static INativeAssemblyStruct InjectedAssembly;

--- a/Il2CppInterop.Runtime/Injection/InjectorHelpers.cs
+++ b/Il2CppInterop.Runtime/Injection/InjectorHelpers.cs
@@ -24,6 +24,7 @@ namespace Il2CppInterop.Runtime.Injection
         internal static Assembly Il2CppMscorlib = typeof(Il2CppSystem.Type).Assembly;
         internal static INativeAssemblyStruct InjectedAssembly;
         internal static INativeImageStruct InjectedImage;
+
         internal static ProcessModule Il2CppModule = Process.GetCurrentProcess()
             .Modules.OfType<ProcessModule>()
             .Single(x => s_assemblies.Contains(x.ModuleName, StringComparer.OrdinalIgnoreCase));
@@ -55,6 +56,7 @@ namespace Il2CppInterop.Runtime.Injection
         private static void CreateInjectedAssembly()
         {
             InjectedAssembly = UnityVersionHandler.NewAssembly();
+
             InjectedImage = UnityVersionHandler.NewImage();
 
             InjectedAssembly.Name.Name = Marshal.StringToHGlobalAnsi("InjectedMonoTypes");
@@ -141,29 +143,18 @@ namespace Il2CppInterop.Runtime.Injection
 
         private static long s_LastInjectedToken = -2;
         internal static readonly ConcurrentDictionary<long, IntPtr> s_InjectedClasses = new();
+
         /// <summary> (namespace, class, image) : class </summary>
         internal static readonly Dictionary<(string _namespace, string _class, IntPtr imagePtr), IntPtr> s_ClassNameLookup = new();
 
         #region Class::Init
+
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void d_ClassInit(Il2CppClass* klass);
+
         internal static d_ClassInit ClassInit;
 
-        private static readonly MemoryUtils.SignatureDefinition[] s_ClassInitSignatures =
-        {
-            new MemoryUtils.SignatureDefinition
-            {
-                pattern = "\xE8\x00\x00\x00\x00\x0F\xB7\x47\x28\x83",
-                mask = "x????xxxxx",
-                xref = true
-            },
-            new MemoryUtils.SignatureDefinition
-            {
-                pattern = "\xE8\x00\x00\x00\x00\x0F\xB7\x47\x48\x48",
-                mask = "x????xxxxx",
-                xref = true
-            }
-        };
+        private static readonly MemoryUtils.SignatureDefinition[] s_ClassInitSignatures = {new MemoryUtils.SignatureDefinition {pattern = "\xE8\x00\x00\x00\x00\x0F\xB7\x47\x28\x83", mask = "x????xxxxx", xref = true}, new MemoryUtils.SignatureDefinition {pattern = "\xE8\x00\x00\x00\x00\x0F\xB7\x47\x48\x48", mask = "x????xxxxx", xref = true}};
 
         private static d_ClassInit FindClassInit()
         {
@@ -188,6 +179,7 @@ namespace Il2CppInterop.Runtime.Injection
                 Logger.Instance.LogTrace("GameAssembly.dll: 0x{Il2CppModuleAddress}", Il2CppModule.BaseAddress.ToInt64().ToString("X2"));
                 throw new NotSupportedException("Failed to use signature for Class::Init and a substitute cannot be found, please create an issue and report your unity version & game");
             }
+
             nint pClassInit = s_ClassInitSignatures
                 .Select(s => MemoryUtils.FindSignatureInModule(Il2CppModule, s))
                 .FirstOrDefault(p => p != 0);
@@ -202,6 +194,8 @@ namespace Il2CppInterop.Runtime.Injection
 
             return Marshal.GetDelegateForFunctionPointer<d_ClassInit>(pClassInit);
         }
+
         #endregion
+
     }
 }

--- a/Il2CppInterop.Runtime/Injection/InjectorHelpers.cs
+++ b/Il2CppInterop.Runtime/Injection/InjectorHelpers.cs
@@ -8,30 +8,34 @@ using System.Reflection.Emit;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Il2CppInterop.Common;
-using Il2CppInterop.Common.Extensions;
-using Il2CppInterop.Common.XrefScans;
 using Il2CppInterop.Runtime.Injection.Hooks;
 using Il2CppInterop.Runtime.Runtime;
 using Il2CppInterop.Runtime.Runtime.VersionSpecific.Assembly;
-using Il2CppInterop.Runtime.Runtime.VersionSpecific.Class;
-using Il2CppInterop.Runtime.Runtime.VersionSpecific.FieldInfo;
 using Il2CppInterop.Runtime.Runtime.VersionSpecific.Image;
 using Il2CppInterop.Runtime.Runtime.VersionSpecific.MethodInfo;
-using Il2CppInterop.Runtime.Startup;
 using Microsoft.Extensions.Logging;
 
 namespace Il2CppInterop.Runtime.Injection
 {
     internal static unsafe class InjectorHelpers
     {
+        private static readonly string[] s_assemblies = {"GameAssembly.dll", "GameAssembly_plus.dll", "GameAssembly.so", "GameAssembly_plus.so", "UserAssembly.dll", "UserAssembly_plus.dll"};
+
         internal static Assembly Il2CppMscorlib = typeof(Il2CppSystem.Type).Assembly;
         internal static INativeAssemblyStruct InjectedAssembly;
         internal static INativeImageStruct InjectedImage;
         internal static ProcessModule Il2CppModule = Process.GetCurrentProcess()
             .Modules.OfType<ProcessModule>()
-            .Single((x) => x.ModuleName is "GameAssembly.dll" or "GameAssembly.so" or "UserAssembly.dll");
+            .Single(x => s_assemblies.Contains(x.ModuleName, StringComparer.OrdinalIgnoreCase));
 
-        internal static IntPtr Il2CppHandle = NativeLibrary.Load("GameAssembly", typeof(InjectorHelpers).Assembly, null);
+        internal static IntPtr Il2CppHandle
+        {
+            get
+            {
+                var assembly = Il2CppModule.ModuleName != null && Il2CppModule.ModuleName.Contains("_plus") ? "GameAssembly_plus" : "GameAssembly";
+                return NativeLibrary.Load(assembly, typeof(InjectorHelpers).Assembly, null);
+            }
+        }
 
         internal static readonly Dictionary<Type, OpCode> StIndOpcodes = new()
         {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Adjustments to include "GameAssembly_plus" in checked assemblies
- There is also a corresponding [BepInEx pull request.](https://github.com/BepInEx/BepInEx/pull/759)
## Motivation and Context
Prince of Persia: The Lost Crown from Ubisoft uses Unity (IL2CPP). As they offer both retail and subscription versions, they have two executables and two game assembly files based on edition. Retail users were fine, but users using Ubisoft+ weren't as process names and game assembly filenames are hardcoded.

The change came about because members of the ultra-wide community requested a fix for the game, and here we discovered it doesn't work on Ubisoft+ due to reasons above.

## How Has This Been Tested?
- I own the retail copy of the game, and have a separate Ubisoft+ subscription, so tested personally.
- Members of the ultrawide community (WSGF etc.), who are a mix of retail and subscription have tested it successfully.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
