### PR TITLE
Fix class injector abstract method handling

### DIFF
--- a/Il2CppInterop.Runtime/Injection/ClassInjector.cs
+++ b/Il2CppInterop.Runtime/Injection/ClassInjector.cs
@@ -362,10 +362,13 @@ public static unsafe partial class ClassInjector
 
                             for (var i = 0; i < m.ParametersCount; i++)
                             {
+                                var parameterName = IL2CPP.il2cpp_method_get_param_name(baseMethod.Pointer, (uint)i);
+                                var otherParameterName = IL2CPP.il2cpp_method_get_param_name(m.Pointer, (uint)i);
+
                                 var parameterInfo = UnityVersionHandler.Wrap(baseMethod.Parameters, i);
                                 var otherParameterInfo = UnityVersionHandler.Wrap(m.Parameters, i);
 
-                                if (Marshal.PtrToStringAnsi(parameterInfo.Name) != Marshal.PtrToStringAnsi(otherParameterInfo.Name)) return false;
+                                if (Marshal.PtrToStringAnsi(parameterName) != Marshal.PtrToStringAnsi(otherParameterName)) return false;
 
                                 if (GetIl2CppTypeFullName(parameterInfo.ParameterType) != GetIl2CppTypeFullName(otherParameterInfo.ParameterType)) return false;
                             }

--- a/Il2CppInterop.Runtime/Injection/ClassInjector.cs
+++ b/Il2CppInterop.Runtime/Injection/ClassInjector.cs
@@ -359,16 +359,12 @@ public static unsafe partial class ClassInjector
                         {
                             if (Marshal.PtrToStringAnsi(m.Name) != name) return false;
                             if (m.ParametersCount != baseMethod.ParametersCount) return false;
+                            if (GetIl2CppTypeFullName(m.ReturnType) != GetIl2CppTypeFullName(baseMethod.ReturnType)) return false;
 
                             for (var i = 0; i < m.ParametersCount; i++)
                             {
-                                var parameterName = IL2CPP.il2cpp_method_get_param_name(baseMethod.Pointer, (uint)i);
-                                var otherParameterName = IL2CPP.il2cpp_method_get_param_name(m.Pointer, (uint)i);
-
                                 var parameterInfo = UnityVersionHandler.Wrap(baseMethod.Parameters, i);
                                 var otherParameterInfo = UnityVersionHandler.Wrap(m.Parameters, i);
-
-                                if (Marshal.PtrToStringAnsi(parameterName) != Marshal.PtrToStringAnsi(otherParameterName)) return false;
 
                                 if (GetIl2CppTypeFullName(parameterInfo.ParameterType) != GetIl2CppTypeFullName(otherParameterInfo.ParameterType)) return false;
                             }


### PR DESCRIPTION
The class injector does checking on abstract methods to match parameter names and types of implemented methods, but the ParameterInfo struct and hence the name field was removed in newer versions of IL2CPP. This is an easy fix because the IL2CPP API has a method to get the name of a parameter from the MethodInfo and index.