### PR TITLE
Upgrade to Harmonyx 2.14

### DIFF
--- a/Il2CppInterop.HarmonySupport/Il2CppInterop.HarmonySupport.csproj
+++ b/Il2CppInterop.HarmonySupport/Il2CppInterop.HarmonySupport.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HarmonyX" Version="2.10.0"/>
+    <PackageReference Include="HarmonyX" Version="2.13.0"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Il2CppInterop.HarmonySupport/Il2CppInterop.HarmonySupport.csproj
+++ b/Il2CppInterop.HarmonySupport/Il2CppInterop.HarmonySupport.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HarmonyX" Version="2.13.0"/>
+    <PackageReference Include="HarmonyX" Version="2.14.0"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Il2CppInterop.Runtime/Injection/DetourProvider.cs
+++ b/Il2CppInterop.Runtime/Injection/DetourProvider.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.InteropServices;
 using Il2CppInterop.Runtime.Startup;
 
 namespace Il2CppInterop.Runtime.Injection;
@@ -10,7 +11,6 @@ public interface IDetour : IDisposable
     nint OriginalTrampoline { get; }
 
     void Apply();
-    T GenerateTrampoline<T>() where T : Delegate;
 }
 
 public interface IDetourProvider
@@ -23,8 +23,8 @@ internal static class Detour
     public static IDetour Apply<T>(nint original, T target, out T trampoline) where T : Delegate
     {
         var detour = Il2CppInteropRuntime.Instance.DetourProvider.Create(original, target);
-        trampoline = detour.GenerateTrampoline<T>();
         detour.Apply();
+        trampoline = Marshal.GetDelegateForFunctionPointer<T>(detour.OriginalTrampoline);
         return detour;
     }
 }


### PR DESCRIPTION
This pr is needed for https://github.com/BepInEx/BepInEx/pull/946

It upgrades Harmonyx to 2.14 and removes the GenerateTrampoline api which wasn't needed by BepInEx and makes it harder to adapt to the reorg MonoMod factory api

Opening as draft for the same reasons than the bepinex pr