### PR TITLE
Special-case System.Enum as a generic constraint

### DIFF
--- a/Il2CppInterop.Generator/Contexts/MethodRewriteContext.cs
+++ b/Il2CppInterop.Generator/Contexts/MethodRewriteContext.cs
@@ -140,8 +140,15 @@ public class MethodRewriteContext
 
                 foreach (var oldConstraint in oldParameter.Constraints)
                 {
-                    if (oldConstraint.Constraint?.FullName == "System.ValueType" ||
-                        oldConstraint.Constraint?.Resolve()?.IsInterface == true) continue;
+                    if (oldConstraint.IsSystemValueType() || oldConstraint.IsInterface())
+                        continue;
+
+                    if (oldConstraint.IsSystemEnum())
+                    {
+                        newParameter.Constraints.Add(new GenericParameterConstraint(
+                            DeclaringType.AssemblyContext.Imports.Module.Enum().ToTypeDefOrRef()));
+                        continue;
+                    }
 
                     newParameter.Constraints.Add(new GenericParameterConstraint(
                         DeclaringType.AssemblyContext.RewriteTypeRef(oldConstraint.Constraint?.ToTypeSignature()).ToTypeDefOrRef()));

--- a/Il2CppInterop.Generator/Extensions/AsmResolverExtensions.cs
+++ b/Il2CppInterop.Generator/Extensions/AsmResolverExtensions.cs
@@ -53,6 +53,12 @@ internal static class AsmResolverExtensions
 
     public static bool IsNested(this TypeSignature type) => type.DeclaringType is not null;
 
+    public static bool IsSystemEnum(this GenericParameterConstraint constraint) => constraint.Constraint?.FullName is "System.Enum";
+
+    public static bool IsSystemValueType(this GenericParameterConstraint constraint) => constraint.Constraint?.FullName is "System.ValueType";
+
+    public static bool IsInterface(this GenericParameterConstraint constraint) => constraint.Constraint?.Resolve()?.IsInterface == true;
+
     public static ITypeDefOrRef? AttributeType(this CustomAttribute attribute) => attribute.Constructor?.DeclaringType;
 
     public static Parameter AddParameter(this MethodDefinition method, TypeSignature parameterSignature, string parameterName, ParameterAttributes parameterAttributes = default)

--- a/Il2CppInterop.Generator/Passes/Pass13FillGenericConstraints.cs
+++ b/Il2CppInterop.Generator/Passes/Pass13FillGenericConstraints.cs
@@ -1,5 +1,7 @@
 using AsmResolver.DotNet;
 using Il2CppInterop.Generator.Contexts;
+using Il2CppInterop.Generator.Extensions;
+using Il2CppInterop.Generator.Utils;
 
 namespace Il2CppInterop.Generator.Passes;
 
@@ -17,9 +19,15 @@ public static class Pass13FillGenericConstraints
                     var newParameter = typeContext.NewType.GenericParameters[i];
                     foreach (var originalConstraint in originalParameter.Constraints)
                     {
-                        if (originalConstraint.Constraint?.FullName is "System.ValueType" ||
-                            originalConstraint.Constraint?.Resolve()?.IsInterface == true)
+                        if (originalConstraint.IsSystemValueType() || originalConstraint.IsInterface())
                             continue;
+
+                        if (originalConstraint.IsSystemEnum())
+                        {
+                            newParameter.Constraints.Add(new GenericParameterConstraint(
+                                typeContext.AssemblyContext.Imports.Module.Enum().ToTypeDefOrRef()));
+                            continue;
+                        }
 
                         newParameter.Constraints.Add(
                             new GenericParameterConstraint(

--- a/Il2CppInterop.Generator/Passes/Pass80UnstripMethods.cs
+++ b/Il2CppInterop.Generator/Passes/Pass80UnstripMethods.cs
@@ -77,8 +77,14 @@ public static class Pass80UnstripMethods
                         newParameter.Attributes = unityMethodGenericParameter.Attributes;
                         foreach (var genericParameterConstraint in unityMethodGenericParameter.Constraints)
                         {
-                            if (genericParameterConstraint.Constraint?.FullName == "System.ValueType") continue;
-                            if (genericParameterConstraint.Constraint?.Resolve()?.IsInterface ?? false) continue;
+                            if (genericParameterConstraint.IsSystemValueType() || genericParameterConstraint.IsInterface())
+                                continue;
+
+                            if (genericParameterConstraint.IsSystemEnum())
+                            {
+                                newParameter.Constraints.Add(new GenericParameterConstraint(imports.Module.Enum().ToTypeDefOrRef()));
+                                continue;
+                            }
 
                             var newType = ResolveTypeInNewAssemblies(context, genericParameterConstraint.Constraint?.ToTypeSignature(),
                                 imports);


### PR DESCRIPTION
Previously:
```cs
public class AdapterView<T, VH, T_AXIS_LIST> : MonoBehaviour
    where VH : ViewHolder<T>
    where T_AXIS_LIST : IL2CppSystem.Enum
{
}
```
Now:
```cs
public class AdapterView<T, VH, T_AXIS_LIST> : MonoBehaviour
    where VH : ViewHolder<T>
    where T_AXIS_LIST : System.Enum
{
}
```