### PR TITLE
Major generator memory leak fix

### DIFF
--- a/Il2CppInterop.Generator/Contexts/AssemblyRewriteContext.cs
+++ b/Il2CppInterop.Generator/Contexts/AssemblyRewriteContext.cs
@@ -9,9 +9,6 @@ namespace Il2CppInterop.Generator.Contexts;
 [DebuggerDisplay($"{{{nameof(GetDebuggerDisplay)}(),nq}}")]
 public class AssemblyRewriteContext
 {
-    // TODO: Dispose
-    private static readonly Dictionary<ModuleDefinition, RuntimeAssemblyReferences> ImportsMap = new();
-
     public readonly RewriteGlobalContext GlobalContext;
 
     public readonly RuntimeAssemblyReferences Imports;
@@ -30,7 +27,7 @@ public class AssemblyRewriteContext
         NewAssembly = newAssembly;
         GlobalContext = globalContext;
 
-        Imports = ImportsMap.GetOrCreate(newAssembly.ManifestModule!,
+        Imports = globalContext.ImportsMap.GetOrCreate(newAssembly.ManifestModule!,
             mod => new RuntimeAssemblyReferences(mod, globalContext));
     }
 

--- a/Il2CppInterop.Generator/Contexts/RewriteGlobalContext.cs
+++ b/Il2CppInterop.Generator/Contexts/RewriteGlobalContext.cs
@@ -19,6 +19,8 @@ public class RewriteGlobalContext : IDisposable
 
     internal readonly Dictionary<(object?, string, int), List<TypeDefinition>> RenameGroups = new();
 
+    internal readonly Dictionary<ModuleDefinition, RuntimeAssemblyReferences> ImportsMap = new();
+
     public RewriteGlobalContext(GeneratorOptions options, IIl2CppMetadataAccess gameAssemblies,
         IMetadataAccess unityAssemblies)
     {

--- a/Il2CppInterop.Generator/Passes/Pass16ScanMethodRefs.cs
+++ b/Il2CppInterop.Generator/Passes/Pass16ScanMethodRefs.cs
@@ -10,8 +10,8 @@ namespace Il2CppInterop.Generator.Passes;
 
 public static class Pass16ScanMethodRefs
 {
-    public static readonly HashSet<long> NonDeadMethods = new();
-    public static IDictionary<long, List<XrefInstance>> MapOfCallers = new Dictionary<long, List<XrefInstance>>();
+    internal static HashSet<long> NonDeadMethods = new();
+    internal static IDictionary<long, List<XrefInstance>> MapOfCallers = new Dictionary<long, List<XrefInstance>>();
 
     public static void DoPass(RewriteGlobalContext context, GeneratorOptions options)
     {

--- a/Il2CppInterop.Generator/Passes/Pass81FillUnstrippedMethodBodies.cs
+++ b/Il2CppInterop.Generator/Passes/Pass81FillUnstrippedMethodBodies.cs
@@ -32,6 +32,9 @@ public static class Pass81FillUnstrippedMethodBodies
             }
         }
 
+        StuffToProcess.Clear();
+        StuffToProcess.Capacity = 0;
+
         Logger.Instance.LogInformation("IL unstrip statistics: {MethodsSucceeded} successful, {MethodsFailed} failed", methodsSucceeded,
             methodsFailed);
     }

--- a/Il2CppInterop.Generator/Runners/InteropAssemblyGenerator.cs
+++ b/Il2CppInterop.Generator/Runners/InteropAssemblyGenerator.cs
@@ -1,4 +1,5 @@
 ﻿using Il2CppInterop.Common;
+using Il2CppInterop.Common.XrefScans;
 using Il2CppInterop.Generator.Contexts;
 using Il2CppInterop.Generator.MetadataAccess;
 using Il2CppInterop.Generator.Passes;
@@ -199,6 +200,12 @@ internal class InteropAssemblyGeneratorRunner : IRunner
         using (new TimingCookie("Writing method pointer map"))
         {
             Pass91GenerateMethodPointerMap.DoPass(rewriteContext, options);
+        }
+
+        using (new TimingCookie("Clearing static data"))
+        {
+            Pass16ScanMethodRefs.MapOfCallers = new Dictionary<long, List<XrefInstance>>();
+            Pass16ScanMethodRefs.NonDeadMethods = [];
         }
 
         Logger.Instance.LogInformation("Done!");


### PR DESCRIPTION
Fixed some static collections holding up to multiple GBs of MethodDefinitions without ever being reset.