### PR TITLE
Reorder a GarbageCollector::RunFinalizer signature to fix matching on SVS

### DIFF
--- a/Il2CppInterop.Runtime/Injection/Hooks/GarbageCollector_RunFinalizer_Patch.cs
+++ b/Il2CppInterop.Runtime/Injection/Hooks/GarbageCollector_RunFinalizer_Patch.cs
@@ -39,16 +39,18 @@ internal class GarbageCollector_RunFinalizer_Patch : Hook<GarbageCollector_RunFi
         },
         new()
         {
-            // Test Game - 2021.3.22 (x64)
-            pattern = "\x40\x53\x48\x83\xEC\x20\x48\x8B\xD9\x48\xC7\x44\x24\x30\x00\x00\x00\x00\x48\x8B",
-            mask = "xxxxxxxxxxxxxxxxxxxx",
+            // V Rising - 2022.3.23 (x64)
+            // Summer Vacation! Scramble - 2021.3.33 (x64)
+            pattern = "\x48\x89\x5C\x24\x10\x48\x89\x74\x24\x18\x57\x48\x83\xEC\x20\x48\x8B\x19",
+            mask = "xxxxxxxxxxxxxxxxxx",
             xref = false,
         },
         new()
         {
-            // V Rising - 2022.3.23 (x64)
-            pattern = "\x48\x89\x5C\x24\x10\x48\x89\x74\x24\x18\x57\x48\x83\xEC\x20\x48\x8B\x19",
-            mask = "xxxxxxxxxxxxxxxxxx",
+            // Test Game - 2021.3.22 (x64)
+            // HoneyCome, DigitalCraft - 2021.3.14 (x64)
+            pattern = "\x40\x53\x48\x83\xEC\x20\x48\x8B\xD9\x48\xC7\x44\x24\x30\x00\x00\x00\x00\x48\x8B",
+            mask = "xxxxxxxxxxxxxxxxxxxx",
             xref = false,
         }
     };


### PR DESCRIPTION
The "Test Game" signature is a bit general that it matched `MS.Internal.Xml.Cache.XPathDocumentNavigator` in Summer Vacation! Scramble(SVS) assembly.

The "V Rising" signature is the one actually matched RunFinalizer in SVS, so reorder this signature before the "Test Game" one.

Also add a comment for "Test Game" signature that matched on HoneyCome and DigitalCraft.