### PR TITLE
Fix issue #140 (AssetBundles cannot be loaded at runtime)

### DIFF
--- a/Il2CppInterop.Runtime/InteropTypes/Il2CppObjectBase.cs
+++ b/Il2CppInterop.Runtime/InteropTypes/Il2CppObjectBase.cs
@@ -82,7 +82,7 @@ public class Il2CppObjectBase
     }
 
     private static readonly Type[] _intPtrTypeArray = { typeof(IntPtr) };
-    private static readonly MethodInfo _getUninitializedObject = typeof(RuntimeHelpers).GetMethod(nameof(FormatterServices.GetUninitializedObject))!;
+    private static readonly MethodInfo _getUninitializedObject = typeof(FormatterServices).GetMethod(nameof(FormatterServices.GetUninitializedObject))!;
     private static readonly MethodInfo _getTypeFromHandle = typeof(Type).GetMethod(nameof(Type.GetTypeFromHandle))!;
     private static readonly MethodInfo _createGCHandle = typeof(Il2CppObjectBase).GetMethod(nameof(CreateGCHandle), BindingFlags.Instance | BindingFlags.NonPublic)!;
     private static readonly FieldInfo _isWrapped = typeof(Il2CppObjectBase).GetField(nameof(isWrapped), BindingFlags.Instance | BindingFlags.NonPublic)!;

--- a/Il2CppInterop.Runtime/InteropTypes/Il2CppObjectBase.cs
+++ b/Il2CppInterop.Runtime/InteropTypes/Il2CppObjectBase.cs
@@ -82,10 +82,10 @@ public class Il2CppObjectBase
     }
 
     private static readonly Type[] _intPtrTypeArray = { typeof(IntPtr) };
-    private static readonly MethodInfo _getUninitializedObject = typeof(RuntimeHelpers).GetMethod(nameof(RuntimeHelpers.GetUninitializedObject))!;
+    private static readonly MethodInfo _getUninitializedObject = typeof(RuntimeHelpers).GetMethod(nameof(FormatterServices.GetUninitializedObject))!;
     private static readonly MethodInfo _getTypeFromHandle = typeof(Type).GetMethod(nameof(Type.GetTypeFromHandle))!;
-    private static readonly MethodInfo _createGCHandle = typeof(Il2CppObjectBase).GetMethod(nameof(CreateGCHandle))!;
-    private static readonly FieldInfo _isWrapped = typeof(Il2CppObjectBase).GetField(nameof(isWrapped))!;
+    private static readonly MethodInfo _createGCHandle = typeof(Il2CppObjectBase).GetMethod(nameof(CreateGCHandle), BindingFlags.Instance | BindingFlags.NonPublic)!;
+    private static readonly FieldInfo _isWrapped = typeof(Il2CppObjectBase).GetField(nameof(isWrapped), BindingFlags.Instance | BindingFlags.NonPublic)!;
 
     internal static class InitializerStore<T>
     {
@@ -126,7 +126,7 @@ public class Il2CppObjectBase
                 // obj.isWrapped = true;
                 il.Emit(OpCodes.Dup);
                 il.Emit(OpCodes.Ldc_I4_1);
-                il.Emit(OpCodes.Stsfld, _isWrapped);
+                il.Emit(OpCodes.Stfld, _isWrapped);
 
                 var parameterlessConstructor = type.GetConstructor(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, Type.EmptyTypes);
                 if (parameterlessConstructor != null)

--- a/Il2CppInterop.Runtime/InteropTypes/Il2CppObjectBase.cs
+++ b/Il2CppInterop.Runtime/InteropTypes/Il2CppObjectBase.cs
@@ -82,7 +82,7 @@ public class Il2CppObjectBase
     }
 
     private static readonly Type[] _intPtrTypeArray = { typeof(IntPtr) };
-    private static readonly MethodInfo _getUninitializedObject = typeof(FormatterServices).GetMethod(nameof(FormatterServices.GetUninitializedObject))!;
+    private static readonly MethodInfo _getUninitializedObject = typeof(RuntimeHelpers).GetMethod(nameof(RuntimeHelpers.GetUninitializedObject))!;
     private static readonly MethodInfo _getTypeFromHandle = typeof(Type).GetMethod(nameof(Type.GetTypeFromHandle))!;
     private static readonly MethodInfo _createGCHandle = typeof(Il2CppObjectBase).GetMethod(nameof(CreateGCHandle), BindingFlags.Instance | BindingFlags.NonPublic)!;
     private static readonly FieldInfo _isWrapped = typeof(Il2CppObjectBase).GetField(nameof(isWrapped), BindingFlags.Instance | BindingFlags.NonPublic)!;
@@ -112,7 +112,7 @@ public class Il2CppObjectBase
                 // However, it could be be user-made or implicit
                 // In that case we set the GCHandle and then call the ctor and let GC destroy any objects created by DerivedConstructorPointer
 
-                // var obj = (T)FormatterServices.GetUninitializedObject(type);
+                // var obj = (T)RuntimeHelpers.GetUninitializedObject(type);
                 il.Emit(OpCodes.Ldtoken, type);
                 il.Emit(OpCodes.Call, _getTypeFromHandle);
                 il.Emit(OpCodes.Call, _getUninitializedObject);

--- a/Il2CppInterop.Runtime/Runtime/Il2CppObjectPool.cs
+++ b/Il2CppInterop.Runtime/Runtime/Il2CppObjectPool.cs
@@ -40,10 +40,14 @@ public static class Il2CppObjectPool
         var newObj = Il2CppObjectBase.InitializerStore<T>.Initializer(ptr);
         unsafe
         {
-            var nativeClassStruct = UnityVersionHandler.Wrap((Il2CppClass*)Il2CppClassPointerStore<T>.NativeClassPtr);
-            if (!nativeClassStruct.HasFinalize)
+            var il2CppClass = (Il2CppClass*)Il2CppClassPointerStore<T>.NativeClassPtr;
+            if (il2CppClass != null)
             {
-                Il2CppSystem.GC.ReRegisterForFinalize(newObj as Object ?? new Object(ptr));
+                var nativeClassStruct = UnityVersionHandler.Wrap(il2CppClass);
+                if (!nativeClassStruct.HasFinalize)
+                {
+                    Il2CppSystem.GC.ReRegisterForFinalize(newObj as Object ?? new Object(ptr));
+                }
             }
         }
 

--- a/Il2CppInterop.Runtime/Runtime/Il2CppObjectPool.cs
+++ b/Il2CppInterop.Runtime/Runtime/Il2CppObjectPool.cs
@@ -40,14 +40,10 @@ public static class Il2CppObjectPool
         var newObj = Il2CppObjectBase.InitializerStore<T>.Initializer(ptr);
         unsafe
         {
-            var il2CppClass = (Il2CppClass*)Il2CppClassPointerStore<T>.NativeClassPtr;
-            if (il2CppClass != null)
+            var nativeClassStruct = UnityVersionHandler.Wrap((Il2CppClass*)Il2CppClassPointerStore<T>.NativeClassPtr);
+            if (!nativeClassStruct.HasFinalize)
             {
-                var nativeClassStruct = UnityVersionHandler.Wrap(il2CppClass);
-                if (!nativeClassStruct.HasFinalize)
-                {
-                    Il2CppSystem.GC.ReRegisterForFinalize(newObj as Object ?? new Object(ptr));
-                }
+                Il2CppSystem.GC.ReRegisterForFinalize(newObj as Object ?? new Object(ptr));
             }
         }
 


### PR DESCRIPTION
Tested on Miside latest version (Unity 2021.3.35f1)

Fixed incorrect IL code

>  Field "Il2CppObjectBase.IsWrapped" is not static field

Fixed MethodInfo references 

> "Il2CppObjectBase.createGCHandle" and "Il2CppObjectBase.isWrapped" are marked as "internal". They are not public outside the current assembly and cannot be accessed as public methods (GetMethod by default returns public methods)

Fixed NullPointerException when trying get native class from Il2CppClassPointerStore.

> As far as I understand, converting IL code to native CPP code does not affect absolutely all classes (judging by the libraries obtained from CPP2IL). For example, AssetBundle in UnityEngine.AssetBundleModule. Therefore, it is impossible to get a pointer to a native class, in fact, it does not exist in the context of Il2CppClassPointerStore.