### PR TITLE
Fix NullPointerException when native class is not present

### DIFF
--- a/Il2CppInterop.Runtime/Runtime/Il2CppObjectPool.cs
+++ b/Il2CppInterop.Runtime/Runtime/Il2CppObjectPool.cs
@@ -40,10 +40,14 @@ public static class Il2CppObjectPool
         var newObj = Il2CppObjectBase.InitializerStore<T>.Initializer(ptr);
         unsafe
         {
-            var nativeClassStruct = UnityVersionHandler.Wrap((Il2CppClass*)Il2CppClassPointerStore<T>.NativeClassPtr);
-            if (!nativeClassStruct.HasFinalize)
+            var il2CppClass = (Il2CppClass*)Il2CppClassPointerStore<T>.NativeClassPtr;
+            if (il2CppClass != null)
             {
-                Il2CppSystem.GC.ReRegisterForFinalize(newObj as Object ?? new Object(ptr));
+                var nativeClassStruct = UnityVersionHandler.Wrap(il2CppClass);
+                if (!nativeClassStruct.HasFinalize)
+                {
+                    Il2CppSystem.GC.ReRegisterForFinalize(newObj as Object ?? new Object(ptr));
+                }
             }
         }
 

--- a/Il2CppInterop.Runtime/Runtime/Il2CppObjectPool.cs
+++ b/Il2CppInterop.Runtime/Runtime/Il2CppObjectPool.cs
@@ -40,14 +40,10 @@ public static class Il2CppObjectPool
         var newObj = Il2CppObjectBase.InitializerStore<T>.Initializer(ptr);
         unsafe
         {
-            var il2CppClass = (Il2CppClass*)Il2CppClassPointerStore<T>.NativeClassPtr;
-            if (il2CppClass != null)
+            var nativeClassStruct = UnityVersionHandler.Wrap((Il2CppClass*)Il2CppClassPointerStore<T>.NativeClassPtr);
+            if (!nativeClassStruct?.HasFinalize is true)
             {
-                var nativeClassStruct = UnityVersionHandler.Wrap(il2CppClass);
-                if (!nativeClassStruct.HasFinalize)
-                {
-                    Il2CppSystem.GC.ReRegisterForFinalize(newObj as Object ?? new Object(ptr));
-                }
+                Il2CppSystem.GC.ReRegisterForFinalize(newObj as Object ?? new Object(ptr));
             }
         }
 

--- a/Il2CppInterop.Runtime/Runtime/Il2CppObjectPool.cs
+++ b/Il2CppInterop.Runtime/Runtime/Il2CppObjectPool.cs
@@ -41,7 +41,7 @@ public static class Il2CppObjectPool
         unsafe
         {
             var nativeClassStruct = UnityVersionHandler.Wrap((Il2CppClass*)Il2CppClassPointerStore<T>.NativeClassPtr);
-            if (!nativeClassStruct?.HasFinalize is true)
+            if (nativeClassStruct?.HasFinalize is false)
             {
                 Il2CppSystem.GC.ReRegisterForFinalize(newObj as Object ?? new Object(ptr));
             }


### PR DESCRIPTION
 A part of [this pull request](https://github.com/BepInEx/Il2CppInterop/pull/197).

Required more in-depth review. Probably unstripped classes do not have a pointer to the native class in Il2CppClassPointerStore context. With UnityEngine.AssetBundleModule.AssetBundle works fine, but i'm not sure about GC Finalize.