### PR TITLE
Add a more specific RunFinalizer signature for Summer Vacation! Scramble

### DIFF
--- a/Il2CppInterop.Runtime/Injection/Hooks/GarbageCollector_RunFinalizer_Patch.cs
+++ b/Il2CppInterop.Runtime/Injection/Hooks/GarbageCollector_RunFinalizer_Patch.cs
@@ -39,6 +39,13 @@ internal class GarbageCollector_RunFinalizer_Patch : Hook<GarbageCollector_RunFi
         },
         new()
         {
+            // Summer Vacation! Scramble - 2021.3.33 (x64)
+            pattern = "\x48\x89\x5c\x24\x10\x48\x89\x74\x24\x18\x57\x48\x83\xec\x20\x48\x8b\x19\x33\xff\x48\x89\x7c\x24\x30\x48\x8b\xf1\xf6\x83\x32\x01\x00\x00\x02\x75\x08\x48\x8b\xcb\xe8",
+            mask = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+            xref = false,
+        },
+        new()
+        {
             // Test Game - 2021.3.22 (x64)
             pattern = "\x40\x53\x48\x83\xEC\x20\x48\x8B\xD9\x48\xC7\x44\x24\x30\x00\x00\x00\x00\x48\x8B",
             mask = "xxxxxxxxxxxxxxxxxxxx",


### PR DESCRIPTION
The "Test Game" signature is a bit general that it matched `MS.Internal.Xml.Cache.XPathDocumentNavigator$$MoveToId` in Summer Vacation! Scramble(SVS) assembly, causing NULL finalier access crashes due to HasFinalize not being handled.

The one actually matched RunFinalizer in SVS is "V Rising" signature, though it's listed after the "Test Game" signature.

Although a simple reorder can fix the issue for SVS, both signatures mentioned are quiet general so this could breaks other games relying on this matching order, otherwise the same crash can happen due to hooking on the wrong location.

Thus I instead add a more specific signature that should solely matches RunFinalizer on SVS or other games with similar compilation options before the too general one.

---

This supersedes #196 and is less aggressive. The added signature is the most specific one so it should not match functions other than RunFinalizer in other games.

Tested working on SVS v1.1.3 and verified that this signature matches RunFinalizer on SVS v1.0.2, v1.1.1 and v1.1.2 assembly.
> [Debug  :Il2CppInterop] GarbageCollector::RunFinalizer found: 0x633D02E0