### PR TITLE
Fix early break

### DIFF
--- a/Il2CppInterop.Common/XrefScans/XrefScanner.cs
+++ b/Il2CppInterop.Common/XrefScans/XrefScanner.cs
@@ -67,9 +67,6 @@ public static class XrefScanner
             decoder.Decode(out var instruction);
             if (decoder.LastError == DecoderError.NoMoreBytes) yield break;
 
-            if (instruction.FlowControl == FlowControl.Return)
-                yield break;
-
             if (instruction.Mnemonic == Mnemonic.Int || instruction.Mnemonic == Mnemonic.Int1)
                 yield break;
 


### PR DESCRIPTION
A function can look like:
jne loc1, ret, call sub, ret

Breaking on the first ret will ignore code after and for example the call will never be exposed. Ignoring ret and just rely on NoMoreBytes and Int1 will be enough