### PR TITLE
AsmResolver System.Enum IsValueType=true workaround. Fixes #211

### DIFF
--- a/Il2CppInterop.Generator/Contexts/AssemblyRewriteContext.cs
+++ b/Il2CppInterop.Generator/Contexts/AssemblyRewriteContext.cs
@@ -88,7 +88,7 @@ public class AssemblyRewriteContext
             if (elementType is GenericParameterSignature)
                 return new GenericInstanceTypeSignature(Imports.Il2CppArrayBase.ToTypeDefOrRef(), false, convertedElementType);
 
-            return new GenericInstanceTypeSignature(convertedElementType.IsValueType
+            return new GenericInstanceTypeSignature(convertedElementType.IsValueType()
                     ? Imports.Il2CppStructArray.ToTypeDefOrRef()
                     : Imports.Il2CppReferenceArray.ToTypeDefOrRef(), false, convertedElementType);
         }
@@ -107,7 +107,7 @@ public class AssemblyRewriteContext
         if (typeRef is GenericInstanceTypeSignature genericInstance)
         {
             var genericType = RewriteTypeRef(genericInstance.GenericType.ToTypeSignature()).ToTypeDefOrRef();
-            var newRef = new GenericInstanceTypeSignature(genericType, genericType.IsValueType);
+            var newRef = new GenericInstanceTypeSignature(genericType, genericType.IsValueType());
             foreach (var originalParameter in genericInstance.TypeArguments)
                 newRef.TypeArguments.Add(RewriteTypeRef(originalParameter));
 

--- a/Il2CppInterop.Generator/Contexts/RewriteGlobalContext.cs
+++ b/Il2CppInterop.Generator/Contexts/RewriteGlobalContext.cs
@@ -223,7 +223,7 @@ public class RewriteGlobalContext : IDisposable
                     {
                         var convertedElementType = resolve(elementType)!;
 
-                        constructorReference = imports.Module.DefaultImporter.ImportMethod(convertedElementType.IsValueType
+                        constructorReference = imports.Module.DefaultImporter.ImportMethod(convertedElementType.IsValueType()
                             ? imports.Il2CppStructArrayctor.Get(convertedElementType)
                             : imports.Il2CppRefrenceArrayctor.Get(convertedElementType));
                     }

--- a/Il2CppInterop.Generator/Contexts/TypeRewriteContext.cs
+++ b/Il2CppInterop.Generator/Contexts/TypeRewriteContext.cs
@@ -50,9 +50,7 @@ public class TypeRewriteContext
                 (ICustomAttributeType)assemblyContext.Imports.ObfuscatedNameAttributector.Value,
                 new CustomAttributeSignature(new CustomAttributeArgument(assemblyContext.Imports.Module.String(), OriginalType.FullName))));
 
-        // A temporary fix for AsmResolver returning IsValueType true for System.Enum
-        // See https://github.com/BepInEx/Il2CppInterop/issues/211 for the discussion
-        if (!OriginalType.IsValueType || OriginalType.FullName == "System.Enum")
+        if (!OriginalType.IsValueType())
             ComputedTypeSpecifics = TypeSpecifics.ReferenceType;
         else if (OriginalType.IsEnum)
             ComputedTypeSpecifics = TypeSpecifics.BlittableStruct;
@@ -71,13 +69,13 @@ public class TypeRewriteContext
     {
         if (NewType.HasGenericParameters())
         {
-            var genericInstanceType = new GenericInstanceTypeSignature(NewType, NewType.IsValueType);
+            var genericInstanceType = new GenericInstanceTypeSignature(NewType, NewType.IsValueType());
             foreach (var newTypeGenericParameter in NewType.GenericParameters)
                 genericInstanceType.TypeArguments.Add(newTypeGenericParameter.ToTypeSignature());
             SelfSubstitutedRef = NewType.Module!.DefaultImporter.ImportTypeSignature(genericInstanceType).ToTypeDefOrRef();
             var genericTypeRef = new GenericInstanceTypeSignature(
                 AssemblyContext.Imports.Il2CppClassPointerStore.ToTypeDefOrRef(),
-                AssemblyContext.Imports.Il2CppClassPointerStore.IsValueType,
+                AssemblyContext.Imports.Il2CppClassPointerStore.IsValueType(),
                 SelfSubstitutedRef.ToTypeSignature());
             ClassPointerFieldRef = ReferenceCreator.CreateFieldReference("NativeClassPtr", AssemblyContext.Imports.Module.IntPtr(),
                 NewType.Module.DefaultImporter.ImportType(genericTypeRef.ToTypeDefOrRef()));
@@ -87,7 +85,7 @@ public class TypeRewriteContext
             SelfSubstitutedRef = NewType;
             var genericTypeRef = new GenericInstanceTypeSignature(
                 AssemblyContext.Imports.Il2CppClassPointerStore.ToTypeDefOrRef(),
-                AssemblyContext.Imports.Il2CppClassPointerStore.IsValueType);
+                AssemblyContext.Imports.Il2CppClassPointerStore.IsValueType());
             if (OriginalType.ToTypeSignature().IsPrimitive() || OriginalType.FullName == "System.String")
                 genericTypeRef.TypeArguments.Add(
                     NewType.Module!.ImportCorlibReference(OriginalType.FullName));

--- a/Il2CppInterop.Generator/Contexts/TypeRewriteContext.cs
+++ b/Il2CppInterop.Generator/Contexts/TypeRewriteContext.cs
@@ -50,7 +50,9 @@ public class TypeRewriteContext
                 (ICustomAttributeType)assemblyContext.Imports.ObfuscatedNameAttributector.Value,
                 new CustomAttributeSignature(new CustomAttributeArgument(assemblyContext.Imports.Module.String(), OriginalType.FullName))));
 
-        if (!OriginalType.IsValueType)
+        // A temporary fix for AsmResolver returning IsValueType true for System.Enum
+        // See https://github.com/BepInEx/Il2CppInterop/issues/211 for the discussion
+        if (!OriginalType.IsValueType || OriginalType.FullName == "System.Enum")
             ComputedTypeSpecifics = TypeSpecifics.ReferenceType;
         else if (OriginalType.IsEnum)
             ComputedTypeSpecifics = TypeSpecifics.BlittableStruct;

--- a/Il2CppInterop.Generator/Extensions/AsmResolverExtensions.cs
+++ b/Il2CppInterop.Generator/Extensions/AsmResolverExtensions.cs
@@ -49,7 +49,7 @@ internal static class AsmResolverExtensions
                 : method.Parameters[argumentIndex - 1];
     }
 
-    public static bool IsReferenceType(this TypeDefinition type) => !type.IsValueType;
+    public static bool IsReferenceType(this TypeDefinition type) => !type.IsValueType();
 
     public static bool HasGenericParameters(this TypeDefinition type) => type.GenericParameters.Count > 0;
 
@@ -69,7 +69,7 @@ internal static class AsmResolverExtensions
 
     public static bool IsPointerLike(this TypeSignature type) => type is PointerTypeSignature or ByReferenceTypeSignature;
 
-    public static bool IsValueTypeLike(this TypeSignature type) => type.IsValueType || type.IsPointerLike();
+    public static bool IsValueTypeLike(this TypeSignature type) => type.IsValueType() || type.IsPointerLike();
 
     public static bool IsSystemEnum(this GenericParameterConstraint constraint) => constraint.Constraint?.FullName is "System.Enum";
 

--- a/Il2CppInterop.Generator/Extensions/ILGeneratorEx.cs
+++ b/Il2CppInterop.Generator/Extensions/ILGeneratorEx.cs
@@ -38,7 +38,7 @@ public static class ILGeneratorEx
             body.Add(OpCodes.Stobj, newType.ToTypeDefOrRef());
             body.Add(OpCodes.Pop);
         }
-        else if (originalType.IsValueType)
+        else if (originalType.IsValueType())
         {
             var typeSpecifics = enclosingType.AssemblyContext.GlobalContext.JudgeSpecificsByOriginalType(originalType);
             if (typeSpecifics == TypeRewriteContext.TypeSpecifics.BlittableStruct)
@@ -52,7 +52,7 @@ public static class ILGeneratorEx
                 body.AddLoadArgument(argumentIndex);
                 body.Add(OpCodes.Call, imports.IL2CPP_Il2CppObjectBaseToPtr.Value);
                 body.Add(OpCodes.Call, imports.IL2CPP_il2cpp_object_unbox.Value);
-                var classPointerTypeRef = new GenericInstanceTypeSignature(imports.Il2CppClassPointerStore.ToTypeDefOrRef(), imports.Il2CppClassPointerStore.IsValueType, newType);
+                var classPointerTypeRef = new GenericInstanceTypeSignature(imports.Il2CppClassPointerStore.ToTypeDefOrRef(), imports.Il2CppClassPointerStore.IsValueType(), newType);
                 var classPointerFieldRef =
                     ReferenceCreator.CreateFieldReference("NativeClassPtr", imports.Module.IntPtr(), classPointerTypeRef.ToTypeDefOrRef());
                 body.Add(OpCodes.Ldsfld, enclosingType.NewType.Module!.DefaultImporter.ImportField(classPointerFieldRef));
@@ -162,12 +162,12 @@ public static class ILGeneratorEx
         var imports = enclosingType.AssemblyContext.Imports;
         if (originalType is ByReferenceTypeSignature)
         {
-            if (newType.GetElementType().IsValueType)
+            if (newType.GetElementType().IsValueType())
             {
                 body.AddLoadArgument(argumentIndex);
                 body.Add(OpCodes.Conv_I);
             }
-            else if (originalType.GetElementType().IsValueType)
+            else if (originalType.GetElementType().IsValueType())
             {
                 body.AddLoadArgument(argumentIndex);
                 body.Add(OpCodes.Ldind_Ref);
@@ -194,11 +194,9 @@ public static class ILGeneratorEx
             Debug.Assert(newType.IsPointerLike());
             body.AddLoadArgument(argumentIndex);
         }
-        // A temporary fix for AsmResolver returning IsValueType true for System.Enum
-        // See https://github.com/BepInEx/Il2CppInterop/issues/211 for the discussion
-        else if (originalType.IsValueType && originalType.FullName != "System.Enum")
+        else if (originalType.IsValueType())
         {
-            if (newType.IsValueType)
+            if (newType.IsValueType())
             {
                 if (argumentIndex == 0 && valueTypeArgument0IsAPointer)
                     body.Add(OpCodes.Ldarg_0);
@@ -304,9 +302,9 @@ public static class ILGeneratorEx
             Debug.Assert(convertedReturnType.IsPointerLike());
             body.Add(OpCodes.Ldloc, pointerVariable);
         }
-        else if (originalReturnType.IsValueType)
+        else if (originalReturnType.IsValueType())
         {
-            if (convertedReturnType.IsValueType)
+            if (convertedReturnType.IsValueType())
             {
                 body.Add(OpCodes.Ldloc, pointerVariable);
                 if (unboxValueType) body.Add(OpCodes.Call, imports.IL2CPP_il2cpp_object_unbox.Value);
@@ -321,7 +319,7 @@ public static class ILGeneratorEx
                 else
                 {
                     Debug.Assert(enclosingType.NewType.Module is not null);
-                    var classPointerTypeRef = new GenericInstanceTypeSignature(imports.Il2CppClassPointerStore.ToTypeDefOrRef(), imports.Il2CppClassPointerStore.IsValueType, convertedReturnType);
+                    var classPointerTypeRef = new GenericInstanceTypeSignature(imports.Il2CppClassPointerStore.ToTypeDefOrRef(), imports.Il2CppClassPointerStore.IsValueType(), convertedReturnType);
                     var classPointerFieldRef =
                         ReferenceCreator.CreateFieldReference("NativeClassPtr", imports.Module.IntPtr(),
                             classPointerTypeRef.ToTypeDefOrRef());

--- a/Il2CppInterop.Generator/Extensions/ILGeneratorEx.cs
+++ b/Il2CppInterop.Generator/Extensions/ILGeneratorEx.cs
@@ -194,7 +194,9 @@ public static class ILGeneratorEx
             Debug.Assert(newType.IsPointerLike());
             body.AddLoadArgument(argumentIndex);
         }
-        else if (originalType.IsValueType)
+        // A temporary fix for AsmResolver returning IsValueType true for System.Enum
+        // See https://github.com/BepInEx/Il2CppInterop/issues/211 for the discussion
+        else if (originalType.IsValueType && originalType.FullName != "System.Enum")
         {
             if (newType.IsValueType)
             {

--- a/Il2CppInterop.Generator/Extensions/TypeReferenceEx.cs
+++ b/Il2CppInterop.Generator/Extensions/TypeReferenceEx.cs
@@ -48,4 +48,9 @@ public static class TypeReferenceEx
 
         return type.Namespace;
     }
+
+    public static bool IsValueType(this ITypeDescriptor type)
+    {
+        return type.IsValueType && type.FullName != "System.Enum";
+    }
 }

--- a/Il2CppInterop.Generator/Extensions/TypeReferenceEx.cs
+++ b/Il2CppInterop.Generator/Extensions/TypeReferenceEx.cs
@@ -49,6 +49,8 @@ public static class TypeReferenceEx
         return type.Namespace;
     }
 
+    // A temporary fix for AsmResolver returning IsValueType true for System.Enum
+    // See https://github.com/BepInEx/Il2CppInterop/issues/211 for the discussion
     public static bool IsValueType(this ITypeDescriptor type)
     {
         return type.IsValueType && type.FullName != "System.Enum";

--- a/Il2CppInterop.Generator/Passes/Pass05CreateRenameGroups.cs
+++ b/Il2CppInterop.Generator/Passes/Pass05CreateRenameGroups.cs
@@ -71,7 +71,7 @@ public static class Pass05CreateRenameGroups
             .Where(it => !it!.Name.IsObfuscated(context.Options));
         var accessName = ClassAccessNames[(int)(typeDefinition.Attributes & TypeAttributes.VisibilityMask)];
 
-        var classifier = typeDefinition.IsInterface ? "Interface" : typeDefinition.IsValueType ? "Struct" : "Class";
+        var classifier = typeDefinition.IsInterface ? "Interface" : typeDefinition.IsValueType() ? "Struct" : "Class";
         var compilerGenertaedString = typeDefinition.Name.StartsWith("<") ? "CompilerGenerated" : "";
         var abstractString = typeDefinition.IsAbstract ? "Abstract" : "";
         var sealedString = typeDefinition.IsSealed ? "Sealed" : "";

--- a/Il2CppInterop.Generator/Passes/Pass21GenerateValueTypeFields.cs
+++ b/Il2CppInterop.Generator/Passes/Pass21GenerateValueTypeFields.cs
@@ -38,7 +38,7 @@ public static class Pass21GenerateValueTypeFields
                         if (field.IsStatic) continue;
 
                         var newField = new FieldDefinition(fieldContext.UnmangledName, field.Attributes.ForcePublic(),
-                            !field.Signature!.FieldType.IsValueType
+                            !field.Signature!.FieldType.IsValueType()
                                 ? assemblyContext.Imports.Module.IntPtr()
                                 : assemblyContext.RewriteTypeRef(field.Signature.FieldType));
 

--- a/Il2CppInterop.Generator/Passes/Pass50GenerateMethods.cs
+++ b/Il2CppInterop.Generator/Passes/Pass50GenerateMethods.cs
@@ -177,8 +177,12 @@ public static class Pass50GenerateMethods
 
                     }
 
+                    // A temporary fix for AsmResolver returning IsValueType true for System.Enum
+                    // See https://github.com/BepInEx/Il2CppInterop/issues/211 for the discussion
+                    var isSystemEnum = originalMethod.DeclaringType!.FullName == "System.Enum";
+
                     if (!originalMethod.DeclaringType!.IsSealed && !originalMethod.IsFinal &&
-                        ((originalMethod.IsVirtual && !originalMethod.DeclaringType.IsValueType) || originalMethod.IsAbstract))
+                        ((originalMethod.IsVirtual && (!originalMethod.DeclaringType.IsValueType || isSystemEnum)) || originalMethod.IsAbstract))
                     {
                         bodyBuilder.Add(OpCodes.Ldarg_0);
                         bodyBuilder.Add(OpCodes.Call, imports.IL2CPP_Il2CppObjectBaseToPtr.Value);

--- a/Il2CppInterop.Generator/Passes/Pass50GenerateMethods.cs
+++ b/Il2CppInterop.Generator/Passes/Pass50GenerateMethods.cs
@@ -60,7 +60,7 @@ public static class Pass50GenerateMethods
                         bodyBuilder.Add(OpCodes.Newobj, imports.Module.DefaultImporter.ImportMethod(originalElementType.FullName switch
                         {
                             "System.String" => imports.Il2CppStringArrayctor_size.Value,
-                            _ when originalElementType.IsValueType => imports.Il2CppStructArrayctor_size.Get(((GenericInstanceTypeSignature)newParameter.ParameterType).TypeArguments[0]),
+                            _ when originalElementType.IsValueType() => imports.Il2CppStructArrayctor_size.Get(((GenericInstanceTypeSignature)newParameter.ParameterType).TypeArguments[0]),
                             _ => imports.Il2CppRefrenceArrayctor_size.Get(((GenericInstanceTypeSignature)newParameter.ParameterType).TypeArguments[0])
                         }));
                         bodyBuilder.Add(OpCodes.Starg, newParameter);
@@ -122,7 +122,7 @@ public static class Pass50GenerateMethods
                         var newParam = newMethod.Parameters[i];
                         // NOTE(Kas): out parameters of value type are passed directly as a pointer to the il2cpp method
                         // since we don't need to perform any additional copies
-                        if (newParam.Definition!.IsOut && !newParam.ParameterType.GetElementType().IsValueType)
+                        if (newParam.Definition!.IsOut && !newParam.ParameterType.GetElementType().IsValueType())
                         {
                             var elementType = newParam.ParameterType.GetElementType();
 
@@ -177,12 +177,8 @@ public static class Pass50GenerateMethods
 
                     }
 
-                    // A temporary fix for AsmResolver returning IsValueType true for System.Enum
-                    // See https://github.com/BepInEx/Il2CppInterop/issues/211 for the discussion
-                    var isSystemEnum = originalMethod.DeclaringType!.FullName == "System.Enum";
-
                     if (!originalMethod.DeclaringType!.IsSealed && !originalMethod.IsFinal &&
-                        ((originalMethod.IsVirtual && (!originalMethod.DeclaringType.IsValueType || isSystemEnum)) || originalMethod.IsAbstract))
+                        ((originalMethod.IsVirtual && !originalMethod.DeclaringType.IsValueType()) || originalMethod.IsAbstract))
                     {
                         bodyBuilder.Add(OpCodes.Ldarg_0);
                         bodyBuilder.Add(OpCodes.Call, imports.IL2CPP_Il2CppObjectBaseToPtr.Value);

--- a/Il2CppInterop.Generator/Passes/Pass79UnstripTypes.cs
+++ b/Il2CppInterop.Generator/Passes/Pass79UnstripTypes.cs
@@ -86,7 +86,7 @@ public static class Pass79UnstripTypes
 
             // Unity assemblies sometimes have struct layouts on classes.
             // This gets overlooked on mono but not on coreclr.
-            if (!clonedType.IsValueType && (clonedType.IsExplicitLayout || clonedType.IsSequentialLayout))
+            if (!clonedType.IsValueType() && (clonedType.IsExplicitLayout || clonedType.IsSequentialLayout))
             {
                 clonedType.IsExplicitLayout = clonedType.IsSequentialLayout = false;
                 clonedType.IsAutoLayout = true;
@@ -119,7 +119,7 @@ public static class Pass79UnstripTypes
 
     private static bool HasNonBlittableFields(TypeDefinition type)
     {
-        if (!type.IsValueType) return false;
+        if (!type.IsValueType()) return false;
 
         var typeSignature = type.ToTypeSignature();
         foreach (var fieldDefinition in type.Fields)
@@ -127,7 +127,7 @@ public static class Pass79UnstripTypes
             if (fieldDefinition.IsStatic || SignatureComparer.Default.Equals(fieldDefinition.Signature?.FieldType, typeSignature))
                 continue;
 
-            if (!fieldDefinition.Signature!.FieldType.IsValueType)
+            if (!fieldDefinition.Signature!.FieldType.IsValueType())
                 return true;
 
             if (fieldDefinition.Signature.FieldType.Namespace?.StartsWith("System") ?? false &&

--- a/Il2CppInterop.Generator/Passes/Pass80UnstripMethods.cs
+++ b/Il2CppInterop.Generator/Passes/Pass80UnstripMethods.cs
@@ -234,7 +234,7 @@ public static class Pass80UnstripMethods
         {
             var baseRef = ResolveTypeInNewAssembliesRaw(context, genericInstance.GenericType.ToTypeSignature(), imports);
             if (baseRef == null) return null;
-            var newInstance = new GenericInstanceTypeSignature(baseRef.ToTypeDefOrRef(), baseRef.IsValueType);
+            var newInstance = new GenericInstanceTypeSignature(baseRef.ToTypeDefOrRef(), baseRef.IsValueType());
             foreach (var unityGenericArgument in genericInstance.TypeArguments)
             {
                 var resolvedArgument = ResolveTypeInNewAssemblies(context, unityGenericArgument, imports);

--- a/Il2CppInterop.Generator/Utils/FieldAccessorGenerator.cs
+++ b/Il2CppInterop.Generator/Utils/FieldAccessorGenerator.cs
@@ -24,13 +24,13 @@ internal static class FieldAccessorGenerator
         CilLocalVariable local0;
         if (field.IsStatic)
         {
-            local0 = new CilLocalVariable(property.Signature.ReturnType.IsValueType
+            local0 = new CilLocalVariable(property.Signature.ReturnType.IsValueType()
                 ? property.Signature.ReturnType
                 : imports.Module.IntPtr());
             getter.CilMethodBody.LocalVariables.Add(local0);
 
             var localIsPointer = false;
-            if (field.Signature!.FieldType.IsValueType && !property.Signature.ReturnType.IsValueType)
+            if (field.Signature!.FieldType.IsValueType() && !property.Signature.ReturnType.IsValueType())
             {
                 var pointerStore = imports.Il2CppClassPointerStore.MakeGenericInstanceType(property.Signature.ReturnType).ToTypeDefOrRef();
                 var pointerStoreType = property.DeclaringType.Module!.DefaultImporter.ImportType(pointerStore);
@@ -53,7 +53,7 @@ internal static class FieldAccessorGenerator
             getterBody.Add(OpCodes.Conv_U);
             getterBody.Add(OpCodes.Call, imports.IL2CPP_il2cpp_field_static_get_value.Value);
 
-            if (property.Signature.ReturnType.IsValueType)
+            if (property.Signature.ReturnType.IsValueType())
             {
                 getterBody.Add(OpCodes.Ldloc, local0);
                 getterBody.Add(OpCodes.Ret);

--- a/Il2CppInterop.Generator/Utils/UnstripGenerator.cs
+++ b/Il2CppInterop.Generator/Utils/UnstripGenerator.cs
@@ -30,14 +30,14 @@ public static class UnstripGenerator
         invokeMethod.ImplAttributes = MethodImplAttributes.CodeTypeMask;
         delegateType.Methods.Add(invokeMethod);
 
-        invokeMethod.Signature!.ReturnType = convertedMethod.Signature!.ReturnType.IsValueType
+        invokeMethod.Signature!.ReturnType = convertedMethod.Signature!.ReturnType.IsValueType()
             ? convertedMethod.Signature.ReturnType
             : imports.Module.IntPtr();
         if (!convertedMethod.IsStatic)
             invokeMethod.AddParameter(imports.Module.IntPtr(), "@this");
         foreach (var convertedParameter in convertedMethod.Parameters)
             invokeMethod.AddParameter(
-                convertedParameter.ParameterType.IsValueType
+                convertedParameter.ParameterType.IsValueType()
                     ? convertedParameter.ParameterType
                     : imports.Module.IntPtr(),
                 convertedParameter.Name,
@@ -64,7 +64,7 @@ public static class UnstripGenerator
         {
             var param = newMethod.Parameters[i];
             var paramType = param.ParameterType;
-            if (paramType.IsValueType || (paramType is ByReferenceTypeSignature && paramType.GetElementType().IsValueType))
+            if (paramType.IsValueType() || (paramType is ByReferenceTypeSignature && paramType.GetElementType().IsValueType()))
             {
                 body.AddLoadArgument(i + argOffset);
             }


### PR DESCRIPTION
This is what you get when you ask a person completely unfamiliar with a complex codebase to submit a PR.

As discussed in #211 I've tested that the code generated for one particular method I was having problem is now fine. I have no slightest idea, if this `IsValueType` matters elsewhere. For, example when a value of this type is passed as a method parameter. I also do not know how to find or test relevant code paths.

IMO, this change is unlikely to break anything already not broken, but this may be not a comprehensive fix. I briefly considered patching this at run-time in AsmResolver using reflections, but this is going to be complex because this is not a field you can change the value off, it actually checks the binary metadata when you call this property, so you would need to patch _code_ not just data to make it work. My guess that we do not want that in Il2CppInterop.

Another workaround is to wrap AsmResolver types, but it looks it will require a whole lot of types to wrap to the point of being unfeasible.

If you can reasonably be sure, that we cover everything here, that's good, but if not, I would not know what else we need to patch.