### PR TITLE
feat: improve garbage collection for injected types & implement finalizer support & stop leaking memory where we can avoid it.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -223,6 +223,9 @@ _pkginfo.txt
 # but keep track of directories ending in .cache
 !?*.[Cc]ache/
 
+# Helix Editor local configuration files
+/.helix/
+
 # Others
 ClientBin/
 ~$*

--- a/Documentation/Class-Injection.md
+++ b/Documentation/Class-Injection.md
@@ -88,17 +88,19 @@ var someInstance = new MyClass(pointer);
   releasing the strong handle it holds and allowing the underlying unmanaged object to eventually be collected in turn.
   When this occurs, however, the finalizer for the managed instance will not be run,
   delaying execution until the unmanaged object is also ready to be garbage collected.
-* The unmanaged-to-managed mapping is a one-to-many relationship. While during typical execution there will be exactly zero,
-  or exactly one extant managed object, in certain situations, such as when the object pool is disabled, there may be any number.
-* Due to the implementation of finalizers, calling `System.GC.SuppressFinalize` or `System.GC.ReRegisterForFinalize` is invalid
-  for all injected types with finalizers, leading to `ObjectCollectedExeption`s at best, and memory safety issues at worst.
-  The methods on `Il2CppSystem.GC` will always work as intended, however.
-  As a corrolary, once an managed instance is finalized, it is no longer valid,
-  so the "resurrection pattern" is not functional for injected types.
+* The unmanaged-to-managed mapping is a one-to-many relationship.
+  While during typical execution there will be exactly zero, or exactly one extant managed object,
+  in certain situations, such as when the object pool is disabled, there may be any number.#
+* Finalizers are supported for injected classes, but note that the managed injector (`~MyClass`) is not invoked predictably.
+  If you want to implement a custom finalizer, define a `private void Il2CppFinalize()` method on your class (see below).
+* Due to the implementation of finalizers, the "resurrection pattern" does not translate directly to injected types.
+  If you do not call `ClassInjector.ResurrectObject` during an object's finalizer,
+  the unmanaged object will be garbage collected and future use will throw `ObjectCollectedException`s.
+  **NB:** You will still also need to call `Il2CppSystem.GC.ReRegisterForFinalize` if applicable.
 
 <details>
 <summary>A detailed example of finalizer behavior for injected classes</summary>
-<br>
+<br>The new managed instance has its `Il2CppFinalize` method called
 
 Consider the following example:
 
@@ -117,30 +119,38 @@ class Foo : Il2CppSystem.Object
     }
 }
 
+ClassInjector.RegisterTypeInIl2Cpp<Foo>();
+
 Foo foobar = new();
 // ... function ends ...
 ```
 
 In the above example, the events occur in this order:
 
-1. The parameterless `Foo` constructor is called:
+1. `Foo` is injected into the il2cpp domain:
+  * The class injector walks the superclasses of `Foo` and collects all the `Il2CppFinalize` methods.
+  * These finalizers are organised in a chain from subclass to superclass.
+  * The injected class is created with an unmanaged finalizer which we can hook into later.
+2. The parameterless `Foo` constructor is called:
   * An unmanaged instance of the injected class is created.
   * A strong handle to the unmanaged instance is put into the managed instance of `Foo`.
-  * The finalizer of the managed instance itself is suppressed,
-    but a hook is installed to watch for its collection.
-2. The managed instance of `Foo` goes out of scope,
-   allowing the managed instance to be garbage collected (without running its finalizer).
-3. Some time later, the managed instance is collected and the hook is triggered:
-  * The strong handle to the unmanaged instance is released
-  * Assuming no other managed or unmanaged references to the object exist,
+3. The managed instance of `Foo` goes out of scope, allowing this instance to be garbage collected.
+4. Some time later, the managed GC will run its finalizer:
+  * Eventually, the GC reaches the finalizer of `Il2CppObjectBase`
+    where the strong handle to the unmanaged instance is released.
+  * Assuming no other managed or unmanaged references to the unmanaged object exist,
     the unmanaged instance of `Foo` can now be garbage collected.
-4. Before this happens, the unmanaged object's finalizer is called:
-  * A fresh managed instance of `Foo` is created and _its_ finalizer is called directly.
-  * This new managed instance is immediately invalidated and forgotten.
-5. The unmanaged object, which has no extant references, is garbage collected with its managed finalizer having run exactly once.
+  * Here, the managed instance of `Foo` is destroyed by the garbage collector,
+    but the unmanaged instance still exists temporarily.
+5. When the unmanaged GC acknowleges this, the unmanaged object's finalizer is called, firing the hook we installed:
+  * A fresh managed instance of `Foo` is created.
+  * This fresh instance is "downgraded" and its strong handle becomes a weak handle,
+    preventing this instance from blocking the garbage collection of the unmanaged instance.
+  * We follow the links in the finalizer chain, running the user-specified finalization method (finally!).
+6. The unmanaged object, which has no extant references, is garbage collected with its managed finalizer having run exactly once.
 
 Note that this complexity is present only for injected classes with finalizers.
-Injected classes without finalizers are collected following a more standard procedure.
+Injected classes without an `Il2CppFinalize` method are collected without running any hooks.
 
 </details>
 

--- a/Documentation/Class-Injection.md
+++ b/Documentation/Class-Injection.md
@@ -100,7 +100,7 @@ var someInstance = new MyClass(pointer);
 
 <details>
 <summary>A detailed example of finalizer behavior for injected classes</summary>
-<br>The new managed instance has its `Il2CppFinalize` method called
+<br>
 
 Consider the following example:
 

--- a/Documentation/Class-Injection.md
+++ b/Documentation/Class-Injection.md
@@ -55,13 +55,13 @@ public class MyClass : SomeIL2CPPClass
 {
     // Used by IL2CPP when creating new instances of this class
     public MyClass(IntPtr ptr) : base(ptr) { }
-    
+
     // Used by managed code when creating new instances of this class
     public MyClass() : base(ClassInjector.DerivedConstructorPointer<MyClass>())
     {
         ClassInjector.DerivedConstructorBody(this);
     }
-    
+
     // Any other methods
 }
 
@@ -110,7 +110,8 @@ class Foo : Il2CppSystem.Object
     {
         ClassInjector.DerivedConstructorBody(this);
     }
-    ~Foo()
+
+    private void Il2CppFinalize()
     {
         // ...
     }

--- a/Il2CppInterop.Runtime/DelegateSupport.cs
+++ b/Il2CppInterop.Runtime/DelegateSupport.cs
@@ -5,12 +5,10 @@ using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime.InteropServices;
 using System.Text;
-using Il2CppInterop.Common;
 using Il2CppInterop.Runtime.Injection;
 using Il2CppInterop.Runtime.InteropTypes;
 using Il2CppInterop.Runtime.InteropTypes.Fields;
 using Il2CppInterop.Runtime.Runtime;
-using Microsoft.Extensions.Logging;
 using Object = Il2CppSystem.Object;
 using ValueType = Il2CppSystem.ValueType;
 
@@ -196,8 +194,9 @@ public static class DelegateSupport
         }
 
         bodyBuilder.BeginCatchBlock(typeof(Exception));
-        bodyBuilder.Emit(OpCodes.Call, typeof(DelegateSupport).GetMethod(nameof(LogException), BindingFlags.Static | BindingFlags.NonPublic)!);
-        bodyBuilder.Emit(OpCodes.Ldstr, "Exception in IL2CPP-to-Managed trampoline, not passing it to il2cpp: ");
+        bodyBuilder.Emit(OpCodes.Ldstr, "IL2CPP-to-Managed delegate trampoline");
+        bodyBuilder.Emit(OpCodes.Call, typeof(ClassInjector).GetMethod(nameof(ClassInjector.LogException),
+            BindingFlags.Static | BindingFlags.NonPublic)!);
 
         bodyBuilder.EndExceptionBlock();
 
@@ -206,11 +205,6 @@ public static class DelegateSupport
         bodyBuilder.Emit(OpCodes.Ret);
 
         return trampoline.CreateDelegate(GetOrCreateDelegateType(signature, managedMethod));
-    }
-
-    private static void LogException(Exception exception)
-    {
-        Logger.Instance.LogError($"Exception in IL2CPP-to-Managed trampoline, not passing it to il2cpp: {exception}");
     }
 
     public static TIl2Cpp? ConvertDelegate<TIl2Cpp>(Delegate @delegate) where TIl2Cpp : Il2CppObjectBase

--- a/Il2CppInterop.Runtime/DelegateSupport.cs
+++ b/Il2CppInterop.Runtime/DelegateSupport.cs
@@ -8,6 +8,7 @@ using System.Text;
 using Il2CppInterop.Common;
 using Il2CppInterop.Runtime.Injection;
 using Il2CppInterop.Runtime.InteropTypes;
+using Il2CppInterop.Runtime.InteropTypes.Fields;
 using Il2CppInterop.Runtime.Runtime;
 using Microsoft.Extensions.Logging;
 using Object = Il2CppSystem.Object;
@@ -133,10 +134,14 @@ public static class DelegateSupport
 
         bodyBuilder.Emit(OpCodes.Ldarg_0);
         bodyBuilder.Emit(OpCodes.Call,
-            typeof(ClassInjectorBase).GetMethod(nameof(ClassInjectorBase.GetMonoObjectFromIl2CppPointer))!);
-        bodyBuilder.Emit(OpCodes.Castclass, typeof(Il2CppToMonoDelegateReference));
+            typeof(Il2CppObjectPool).GetMethod(nameof(Il2CppObjectPool.Get))!
+                .MakeGenericMethod(typeof(Il2CppToMonoDelegateReference)));
         bodyBuilder.Emit(OpCodes.Ldfld,
-            typeof(Il2CppToMonoDelegateReference).GetField(nameof(Il2CppToMonoDelegateReference.ReferencedDelegate)));
+            typeof(Il2CppToMonoDelegateReference).GetField(nameof(Il2CppToMonoDelegateReference.MethodInfo)));
+        bodyBuilder.Emit(OpCodes.Call,
+            typeof(Il2CppValueField<IntPtr>).GetMethod(nameof(Il2CppValueField<IntPtr>.Get)));
+        bodyBuilder.Emit(OpCodes.Call,
+            typeof(DelegateSupport).GetMethod(nameof(DelegateSupport.GetStoredDelegate), BindingFlags.NonPublic | BindingFlags.Static));
 
         for (var i = 0; i < managedParameters.Length; i++)
         {
@@ -190,15 +195,9 @@ public static class DelegateSupport
             bodyBuilder.Emit(OpCodes.Stloc, returnLocal);
         }
 
-        var exceptionLocal = bodyBuilder.DeclareLocal(typeof(Exception));
         bodyBuilder.BeginCatchBlock(typeof(Exception));
-        bodyBuilder.Emit(OpCodes.Stloc, exceptionLocal);
+        bodyBuilder.Emit(OpCodes.Call, typeof(DelegateSupport).GetMethod(nameof(LogException), BindingFlags.Static | BindingFlags.NonPublic)!);
         bodyBuilder.Emit(OpCodes.Ldstr, "Exception in IL2CPP-to-Managed trampoline, not passing it to il2cpp: ");
-        bodyBuilder.Emit(OpCodes.Ldloc, exceptionLocal);
-        bodyBuilder.Emit(OpCodes.Callvirt, typeof(object).GetMethod(nameof(ToString))!);
-        bodyBuilder.Emit(OpCodes.Call,
-            typeof(string).GetMethod(nameof(string.Concat), new[] { typeof(string), typeof(string) })!);
-        bodyBuilder.Emit(OpCodes.Call, typeof(DelegateSupport).GetMethod(nameof(LogError), BindingFlags.Static | BindingFlags.NonPublic)!);
 
         bodyBuilder.EndExceptionBlock();
 
@@ -209,9 +208,9 @@ public static class DelegateSupport
         return trampoline.CreateDelegate(GetOrCreateDelegateType(signature, managedMethod));
     }
 
-    private static void LogError(string message)
+    private static void LogException(Exception exception)
     {
-        Logger.Instance.LogError("{Message}", message);
+        Logger.Instance.LogError($"Exception in IL2CPP-to-Managed trampoline, not passing it to il2cpp: {exception}");
     }
 
     public static TIl2Cpp? ConvertDelegate<TIl2Cpp>(Delegate @delegate) where TIl2Cpp : Il2CppObjectBase
@@ -289,6 +288,8 @@ public static class DelegateSupport
         methodInfo.IsMarshalledFromNative = true;
 
         var delegateReference = new Il2CppToMonoDelegateReference(@delegate, methodInfo.Pointer);
+        // Leak the object so we never have to do this again.
+        GCHandle.Alloc(delegateReference);
 
         Il2CppSystem.Delegate converted;
         if (UnityVersionHandler.MustUseDelegateConstructor)
@@ -316,6 +317,9 @@ public static class DelegateSupport
 
         return converted.Cast<TIl2Cpp>();
     }
+
+    private static readonly ConcurrentDictionary<IntPtr, Delegate> s_storedDelegates = new();
+    private static Delegate GetStoredDelegate(IntPtr methodInfoPtr) => s_storedDelegates[methodInfoPtr];
 
     internal class MethodSignature : IEquatable<MethodSignature>
     {
@@ -390,8 +394,7 @@ public static class DelegateSupport
 
     private class Il2CppToMonoDelegateReference : Object
     {
-        public IntPtr MethodInfo;
-        public Delegate ReferencedDelegate;
+        public Il2CppValueField<IntPtr> MethodInfo;
 
         public Il2CppToMonoDelegateReference(IntPtr obj0) : base(obj0)
         {
@@ -402,15 +405,15 @@ public static class DelegateSupport
         {
             ClassInjector.DerivedConstructorBody(this);
 
-            ReferencedDelegate = referencedDelegate;
-            MethodInfo = methodInfo;
+            MethodInfo!.Set(methodInfo);
+            s_storedDelegates[methodInfo] = referencedDelegate;
         }
 
         ~Il2CppToMonoDelegateReference()
         {
             Marshal.FreeHGlobal(MethodInfo);
-            MethodInfo = IntPtr.Zero;
-            ReferencedDelegate = null;
+            MethodInfo.Set(IntPtr.Zero);
+            s_storedDelegates.TryRemove(MethodInfo, out _);
         }
     }
 }

--- a/Il2CppInterop.Runtime/DelegateSupport.cs
+++ b/Il2CppInterop.Runtime/DelegateSupport.cs
@@ -403,7 +403,7 @@ public static class DelegateSupport
             s_storedDelegates[methodInfo] = referencedDelegate;
         }
 
-        ~Il2CppToMonoDelegateReference()
+        private void Il2CppFinalize()
         {
             Marshal.FreeHGlobal(MethodInfo);
             MethodInfo.Set(IntPtr.Zero);

--- a/Il2CppInterop.Runtime/Injection/ClassInjector.cs
+++ b/Il2CppInterop.Runtime/Injection/ClassInjector.cs
@@ -63,6 +63,17 @@ public class RegisterTypeOptions
     public Il2CppInterfaceCollection? Interfaces { get; init; } = null;
 }
 
+internal record FinalizerChain(Delegate finalizer, FinalizerChain? next)
+{
+    public FinalizerChain? next = next;
+
+    public void Execute<T>(T obj) where T : Il2CppObjectBase
+    {
+        ((Action<T>)finalizer)(obj);
+        next?.Execute<T>(obj);
+    }
+}
+
 public static unsafe partial class ClassInjector
 {
     /// <summary> type.FullName </summary>
@@ -74,7 +85,7 @@ public static unsafe partial class ClassInjector
 
     private static readonly ConcurrentDictionary<string, Delegate> InvokerCache = new();
     private static readonly ConcurrentDictionary<Type, InjectedInitializationDelegate> DerivedConstructorBodyCache = new();
-    internal static readonly ConcurrentDictionary<Type, Delegate> ManualFinalizeCache = new();
+    internal static readonly ConcurrentDictionary<Type, FinalizerChain?> FinalizerChainCache = new();
 
     private static readonly ConcurrentDictionary<(Type type, FieldAttributes attrs), IntPtr>
         _injectedFieldTypes = new();
@@ -209,19 +220,30 @@ public static unsafe partial class ClassInjector
                     $"Type with FullName {type.FullName} is already injected. Don't inject the same type twice, or use a different namespace");
         }
 
-        MethodInfo? DiscernIfTypeIsManuallyFinalizable(Type type)
+        static void InternFinalizerChain(Type? type)
         {
-            if (type == typeof(Il2CppObjectBase))
-                return null;
-            if (type.GetMethod("Finalize", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly) is MethodInfo m)
-                return m;
-            return type.BaseType != null ? DiscernIfTypeIsManuallyFinalizable(type.BaseType) : null;
+            FinalizerChain? last = null;
+            while (type != null)
+            {
+                if (FinalizerChainCache.TryGetValue(type, out FinalizerChain? next))
+                {
+                    if (last != null) last.next = next;
+                    break;
+                }
+
+                if (type.GetMethod("Il2CppFinalize", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly) is MethodInfo m)
+                {
+                    next = new(m.CreateDelegate(typeof(Action<>).MakeGenericType(type)), last);
+                    if (last != null) last.next = next;
+                    FinalizerChainCache[type] = next;
+                    last = next;
+                }
+
+                type = type.BaseType;
+            }
         }
 
-        if (DiscernIfTypeIsManuallyFinalizable(type) is MethodInfo finalize)
-        {
-            ManualFinalizeCache[type] = finalize.CreateDelegate(typeof(Action<>).MakeGenericType(type));
-        }
+        InternFinalizerChain(type);
 
         var interfaceFunctionCount = interfaces.Sum(i => i.MethodCount);
         var classPointer = UnityVersionHandler.NewClass(baseClassPointer.VtableCount + interfaceFunctionCount);
@@ -737,7 +759,13 @@ public static unsafe partial class ClassInjector
 
     internal static bool IsTypeManuallyFinalizable(Type targetType)
     {
-        return ManualFinalizeCache.ContainsKey(targetType);
+        return FinalizerChainCache.ContainsKey(targetType);
+    }
+
+    private static void RunFinalizer<T>(IntPtr ptr) where T : Il2CppObjectBase
+    {
+        T ephemeral = Il2CppObjectInitializer.NewWeak<T>(ptr);
+        ClassInjector.FinalizerChainCache[typeof(T)]!.Execute(ephemeral);
     }
 
     private static VoidCtorDelegate CreateFinalizeMethod(Type targetType)
@@ -753,7 +781,7 @@ public static unsafe partial class ClassInjector
         // Finalize from within the object pool:
         body.Emit(OpCodes.Ldarg_0);
         body.Emit(OpCodes.Call,
-            typeof(Il2CppFinalizers).GetMethod(nameof(Il2CppFinalizers.RunFinalizer),
+            typeof(ClassInjector).GetMethod(nameof(ClassInjector.RunFinalizer),
                     BindingFlags.NonPublic | BindingFlags.Static)!.MakeGenericMethod(targetType));
 
         // Catch any exceptions:

--- a/Il2CppInterop.Runtime/Injection/ClassInjector.cs
+++ b/Il2CppInterop.Runtime/Injection/ClassInjector.cs
@@ -119,6 +119,11 @@ public static unsafe partial class ClassInjector
         return method.CreateDelegate<InjectedInitializationDelegate>();
     }
 
+    public static void ResurrectObject(Il2CppObjectBase obj)
+    {
+        Il2CppObjectBase.Upgrade(obj);
+    }
+
     public static bool IsTypeRegisteredInIl2Cpp<T>() where T : class
     {
         return IsTypeRegisteredInIl2Cpp(typeof(T));

--- a/Il2CppInterop.Runtime/Injection/ClassInjector.cs
+++ b/Il2CppInterop.Runtime/Injection/ClassInjector.cs
@@ -236,7 +236,7 @@ public static unsafe partial class ClassInjector
                     break;
                 }
 
-                if (type.GetMethod("Il2CppFinalize", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly) is MethodInfo m)
+                if (type.GetMethod("Il2CppFinalize", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly, new Type[0]) is MethodInfo m)
                 {
                     next = new(m.CreateDelegate(typeof(Action<>).MakeGenericType(type)), last);
                     if (last != null) last.next = next;

--- a/Il2CppInterop.Runtime/InteropTypes/Il2CppObjectBase.cs
+++ b/Il2CppInterop.Runtime/InteropTypes/Il2CppObjectBase.cs
@@ -113,9 +113,4 @@ public class Il2CppObjectBase
 
         return Il2CppObjectInitializer.New<T>(Pointer);
     }
-
-    public static void Resurrect(Il2CppObjectBase obj)
-    {
-        Upgrade(obj);
-    }
 }

--- a/Il2CppInterop.Runtime/InteropTypes/Il2CppObjectBase.cs
+++ b/Il2CppInterop.Runtime/InteropTypes/Il2CppObjectBase.cs
@@ -1,23 +1,14 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using Il2CppInterop.Common;
 using Il2CppInterop.Runtime.Runtime;
-using Microsoft.Extensions.Logging;
 
 namespace Il2CppInterop.Runtime.InteropTypes;
-
-public enum Il2CppObjectFinalizerState
-{
-    Free = 0,
-    Glued = 1,
-}
 
 public class Il2CppObjectBase
 {
     internal bool isWrapped;
     internal IntPtr pooledPtr;
-    internal Il2CppObjectFinalizerState finalizerState;
 
     private bool wasDestroyed;
     private nint myGcHandle;
@@ -29,14 +20,7 @@ public class Il2CppObjectBase
 
     ~Il2CppObjectBase()
     {
-        switch (finalizerState)
-        {
-            case Il2CppObjectFinalizerState.Free:
-                Il2CppObjectPool.Free(myGcHandle, pooledPtr);
-                break;
-            case Il2CppObjectFinalizerState.Glued:
-                throw new NotSupportedException("Object was garbage collected too early. Perhaps GC.ReRegisterForFinalize was incorrectly called?");
-        }
+        Il2CppObjectPool.Free(myGcHandle, pooledPtr);
     }
 
     public IntPtr ObjectClass => IL2CPP.il2cpp_object_get_class(Pointer);
@@ -72,16 +56,24 @@ public class Il2CppObjectBase
             return;
 
         myGcHandle = IL2CPP.il2cpp_gchandle_new(objHdl, false);
+
         isWrapped = true;
     }
 
-    internal FinalizerContainer CreateFinalizerContainer()
+    internal static void Downgrade(Il2CppObjectBase obj)
     {
-        return new FinalizerContainer()
-        {
-            gcHandle = myGcHandle,
-            ptr = Pointer,
-        };
+        nint strong = obj.myGcHandle;
+        obj.myGcHandle = IL2CPP.il2cpp_gchandle_new_weakref(obj.Pointer, false);
+        IL2CPP.il2cpp_gchandle_free(strong);
+    }
+
+    internal static void Upgrade(Il2CppObjectBase obj)
+    {
+        nint weak = obj.myGcHandle;
+        obj.myGcHandle = IL2CPP.il2cpp_gchandle_new(obj.Pointer, false);
+        IL2CPP.il2cpp_gchandle_free(weak);
+        Il2CppObjectPool.Intern(obj);
+
     }
 
     public T Cast<T>() where T : Il2CppObjectBase
@@ -120,5 +112,10 @@ public class Il2CppObjectBase
             return null;
 
         return Il2CppObjectInitializer.New<T>(Pointer);
+    }
+
+    public static void Resurrect(Il2CppObjectBase obj)
+    {
+        Upgrade(obj);
     }
 }

--- a/Il2CppInterop.Runtime/Runtime/Il2CppObjectInitializer.cs
+++ b/Il2CppInterop.Runtime/Runtime/Il2CppObjectInitializer.cs
@@ -1,13 +1,12 @@
 using System;
-using System.Collections.Concurrent;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
-using Il2CppInterop.Runtime;
 using Il2CppInterop.Runtime.Injection;
 using Il2CppInterop.Runtime.InteropTypes;
-using Il2CppInterop.Runtime.Runtime;
+
+namespace Il2CppInterop.Runtime.Runtime;
 
 internal static class Il2CppObjectInitializer
 {
@@ -16,10 +15,12 @@ internal static class Il2CppObjectInitializer
         return InitializerStore<T>.Initialize(ptr);
     }
 
-    /// <summary> Identical to <code>New</code> except skipping the glue code for injected finalizers.</summary>
-    internal static T NewWithoutGlue<T>(IntPtr ptr) where T : Il2CppObjectBase
+    /// <summary>
+    /// Creates a proxy to a new <c>T</c> without holding a strong handle.
+    /// </summary>
+    internal static T NewWeak<T>(IntPtr ptr) where T : Il2CppObjectBase
     {
-        return InitializerStore<T>.InitializeWithoutGlue(ptr);
+        return InitializerStore<T>.InitializeWeak(ptr);
     }
 
     private static readonly MethodInfo _getUninitializedObject = typeof(RuntimeHelpers).GetMethod(nameof(RuntimeHelpers.GetUninitializedObject))!;
@@ -69,20 +70,18 @@ internal static class Il2CppObjectInitializer
         EmitGCHandling(il, type, false);
     }
 
-    private static readonly MethodInfo _internWeak = typeof(Il2CppObjectPool).GetMethod(nameof(Il2CppObjectPool.InternWeak))!;
-    private static readonly MethodInfo _glue = typeof(Il2CppFinalizers).GetMethod(nameof(Il2CppFinalizers.FinalizerGlue), BindingFlags.NonPublic | BindingFlags.Static)!;
+    private static readonly MethodInfo _intern = typeof(Il2CppObjectPool).GetMethod(nameof(Il2CppObjectPool.Intern))!;
+    private static readonly MethodInfo _downgrade = typeof(Il2CppObjectBase).GetMethod(nameof(Il2CppObjectBase.Downgrade), BindingFlags.NonPublic | BindingFlags.Static)!;
 
-    private static void EmitGCHandling(ILGenerator il, Type type, bool useGlue)
+    private static void EmitGCHandling(ILGenerator il, Type type, bool weak)
     {
-        if (useGlue && ClassInjector.IsTypeManuallyFinalizable(type))
+        if (!weak)
         {
-            il.Emit(OpCodes.Dup);
-            il.Emit(OpCodes.Call, _internWeak);
-            il.Emit(OpCodes.Call, _glue);
+            il.Emit(OpCodes.Call, _intern);
         }
         else
         {
-            il.Emit(OpCodes.Call, _internWeak);
+            il.Emit(OpCodes.Call, _downgrade);
         }
     }
 
@@ -109,10 +108,10 @@ internal static class Il2CppObjectInitializer
 
         public static Initializer? initialize;
         public static Initializer? initializeWithoutGlue;
-        public static Initializer Initialize => initialize ??= Create(true);
-        public static Initializer InitializeWithoutGlue => initializeWithoutGlue ??= Create(false);
+        public static Initializer Initialize => initialize ??= Create(false);
+        public static Initializer InitializeWeak => initializeWithoutGlue ??= Create(true);
 
-        private static Initializer Create(bool useGlue)
+        private static Initializer Create(bool weak)
         {
             var type = Il2CppClassPointerStore<T>.CreatedTypeRedirect ?? typeof(T);
 
@@ -121,7 +120,7 @@ internal static class Il2CppObjectInitializer
                 .Where(ClassInjector.IsFieldEligible)
                 .ToArray();
 
-            string methodName = useGlue ? "Initialize" : "InitializeWithoutGlue";
+            string methodName = weak ? "InitializeWeak" : "Initialize";
             var dynamicMethod = new DynamicMethod($"{methodName}<{typeof(T).AssemblyQualifiedName}>", type, _intPtrTypeArray);
             dynamicMethod.DefineParameter(0, ParameterAttributes.None, "pointer");
 
@@ -129,46 +128,10 @@ internal static class Il2CppObjectInitializer
             EmitCtorCall(il, type);
             EmitFieldInitialization(il, type, fieldsToInitialize);
             il.Emit(OpCodes.Dup);
-            EmitGCHandling(il, type, useGlue);
+            EmitGCHandling(il, type, weak);
             il.Emit(OpCodes.Ret);
 
             return dynamicMethod.CreateDelegate<Initializer>();
         }
     }
 }
-
-// NB: Since a managed object might be garbage collected before its unmanaged counterpart is ready,
-//     we need another object (this one) to handle the cleanup.
-//     The objects' lifetimes are linked by the s_finalizers ephemeron on Il2CppFinalizers.
-internal class FinalizerContainer
-{
-    public nint gcHandle;
-    public IntPtr ptr;
-
-    ~FinalizerContainer()
-    {
-        Il2CppObjectPool.Free(gcHandle, ptr);
-    }
-}
-
-internal static class Il2CppFinalizers
-{
-    internal static readonly ConcurrentDictionary<IntPtr, byte> s_dying = new();
-    internal static readonly ConditionalWeakTable<Il2CppObjectBase, FinalizerContainer> s_ephemeron = new();
-
-    internal static void RunFinalizer<T>(IntPtr ptr) where T : Il2CppObjectBase
-    {
-        T ephemeral = Il2CppObjectInitializer.NewWithoutGlue<T>(ptr);
-        Action<T> finalize = (Action<T>)ClassInjector.ManualFinalizeCache[typeof(T)];
-        finalize(ephemeral);
-        GC.SuppressFinalize(ephemeral);
-    }
-
-    internal static void FinalizerGlue(Il2CppObjectBase obj)
-    {
-        s_ephemeron.Add(obj, obj.CreateFinalizerContainer());
-        obj.finalizerState = Il2CppObjectFinalizerState.Glued;
-        GC.SuppressFinalize(obj);
-    }
-}
-

--- a/Il2CppInterop.Runtime/Runtime/Il2CppObjectPool.cs
+++ b/Il2CppInterop.Runtime/Runtime/Il2CppObjectPool.cs
@@ -1,10 +1,54 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using Il2CppInterop.Common;
 using Il2CppInterop.Runtime.InteropTypes;
+using Microsoft.Extensions.Logging;
 using Object = Il2CppSystem.Object;
 
 namespace Il2CppInterop.Runtime.Runtime;
+
+// NB: Since we may call GC.SuppressFinalize on managed objects, we need another object (this one) to handle the cleanup.
+// The objects' lifetimes are linked by the s_finalizers ephemeron on Il2CppFinalizers.
+internal class FinalizerContainer
+{
+    public nint gcHandle;
+    public IntPtr pooledPtr;
+
+    ~FinalizerContainer() => Il2CppObjectPool.Free(gcHandle, pooledPtr);
+}
+
+internal static class Il2CppFinalizers
+{
+    // Dying objects are never duplicated.
+    internal static readonly ConcurrentDictionary<IntPtr, byte> s_dying = new();
+    internal static readonly ConditionalWeakTable<Il2CppObjectBase, FinalizerContainer> s_finalizers = new();
+
+    internal static void OnDeath(IntPtr ptr)
+    {
+        s_dying.Remove(ptr, out _);
+    }
+
+    internal static bool ShouldFinalize(IntPtr ptr)
+    {
+        return !s_dying.ContainsKey(ptr);
+    }
+
+    internal static void Finalize(Il2CppObjectBase obj)
+    {
+        obj.finalizerState = Il2CppObjectFinalizerState.Now;
+        s_dying[obj.Pointer] = 0;
+        GC.ReRegisterForFinalize(obj);
+    }
+
+    internal static void OverrideFinalize(Il2CppObjectBase obj, FinalizerContainer finalizer)
+    {
+        GC.SuppressFinalize(obj);
+        obj.finalizerState = Il2CppObjectFinalizerState.NotYet;
+        s_finalizers.Add(obj, finalizer);
+    }
+}
 
 public static class Il2CppObjectPool
 {
@@ -17,24 +61,41 @@ public static class Il2CppObjectPool
         s_cache.TryRemove(ptr, out _);
     }
 
+    internal static void Free(nint unmanagedGcHandle, IntPtr ptr)
+    {
+        IL2CPP.il2cpp_gchandle_free(unmanagedGcHandle);
+        if (ptr != IntPtr.Zero) Il2CppObjectPool.Remove(ptr);
+    }
+
+    public static void InternWeak(Il2CppObjectBase obj)
+    {
+        IntPtr ptr = obj.Pointer;
+        obj.pooledPtr = ptr;
+        s_cache[ptr] = new(obj);
+    }
+
+    internal static bool ReferenceIsDead(IntPtr ptr)
+    {
+        return s_cache.TryGetValue(ptr, out var reference) && !reference.TryGetTarget(out _);
+    }
+
     public static T Get<T>(IntPtr ptr)
     {
-        if (ptr == IntPtr.Zero) return default;
-
-        var ownClass = IL2CPP.il2cpp_object_get_class(ptr);
-        if (RuntimeSpecificsStore.IsInjected(ownClass))
-        {
-            var monoObject = ClassInjectorBase.GetMonoObjectFromIl2CppPointer(ptr);
-            if (monoObject is T monoObjectT) return monoObjectT;
-        }
+        if (ptr == IntPtr.Zero || Il2CppFinalizers.s_dying.ContainsKey(ptr)) return default;
 
         if (DisableCaching) return Il2CppObjectBase.InitializerStore<T>.Initializer(ptr);
 
-        if (s_cache.TryGetValue(ptr, out var reference) && reference.TryGetTarget(out var cachedObject))
+        if (s_cache.TryGetValue(ptr, out var reference))
         {
-            if (cachedObject is T cachedObjectT) return cachedObjectT;
-            cachedObject.pooledPtr = IntPtr.Zero;
-            // This leaves the case when you cast to an interface handled as if nothing was cached
+            if (reference.TryGetTarget(out var cachedObject))
+            {
+                if (cachedObject is T cachedObjectT) return cachedObjectT;
+
+                // This leaves the case when you cast to an interface, handled as if nothing was cached
+            }
+
+            // If the cached object no longer exists, delete the irrelevant entry if we can:
+            Remove(ptr);
         }
 
         var newObj = Il2CppObjectBase.InitializerStore<T>.Initializer(ptr);
@@ -48,8 +109,8 @@ public static class Il2CppObjectPool
         }
 
         var il2CppObjectBase = Unsafe.As<T, Il2CppObjectBase>(ref newObj);
-        s_cache[ptr] = new WeakReference<Il2CppObjectBase>(il2CppObjectBase);
-        il2CppObjectBase.pooledPtr = ptr;
+        if (il2CppObjectBase.Pointer != ptr) Logger.Instance.LogError("Pointer interned at wrong address!");
+        InternWeak(il2CppObjectBase);
         return newObj;
     }
 }

--- a/Il2CppInterop.Runtime/Runtime/Il2CppObjectPool.cs
+++ b/Il2CppInterop.Runtime/Runtime/Il2CppObjectPool.cs
@@ -23,7 +23,7 @@ public static class Il2CppObjectPool
         Remove(ptr);
     }
 
-    public static void InternWeak(Il2CppObjectBase obj)
+    public static void Intern(Il2CppObjectBase obj)
     {
         IntPtr ptr = obj.Pointer;
         obj.pooledPtr = ptr;
@@ -32,7 +32,7 @@ public static class Il2CppObjectPool
 
     public static T Get<T>(IntPtr ptr)
     {
-        if (ptr == IntPtr.Zero || Il2CppFinalizers.s_dying.ContainsKey(ptr))
+        if (ptr == IntPtr.Zero)
         {
             return default!;
         }

--- a/Il2CppInterop.Runtime/Runtime/Il2CppObjectPool.cs
+++ b/Il2CppInterop.Runtime/Runtime/Il2CppObjectPool.cs
@@ -7,7 +7,7 @@ namespace Il2CppInterop.Runtime.Runtime;
 
 public static class Il2CppObjectPool
 {
-    public static bool DisableCaching { get; set; }
+    internal static bool DisableCaching { get; set; }
 
     private static readonly ConcurrentDictionary<IntPtr, WeakReference<Il2CppObjectBase>> s_cache = new();
 

--- a/Il2CppInterop.Runtime/Runtime/ObjectLifecycle.cs
+++ b/Il2CppInterop.Runtime/Runtime/ObjectLifecycle.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using Il2CppInterop.Runtime;
+using Il2CppInterop.Runtime.Injection;
+using Il2CppInterop.Runtime.InteropTypes;
+using Il2CppInterop.Runtime.Runtime;
+
+internal static class Il2CppObjectInitializer
+{
+    internal static T New<T>(IntPtr ptr)
+    {
+        return InitializerStore<T>.Initialize(ptr);
+    }
+
+    /// <summary> Identical to <code>New</code> except skipping the glue code for injected finalizers.</summary>
+    internal static T NewWithoutGlue<T>(IntPtr ptr) where T : Il2CppObjectBase
+    {
+        return InitializerStore<T>.InitializeWithoutGlue(ptr);
+    }
+
+    private static readonly MethodInfo _getUninitializedObject = typeof(RuntimeHelpers).GetMethod(nameof(RuntimeHelpers.GetUninitializedObject))!;
+    private static readonly MethodInfo _getTypeFromHandle = typeof(Type).GetMethod(nameof(Type.GetTypeFromHandle))!;
+    private static readonly MethodInfo _createGCHandle = typeof(Il2CppObjectBase).GetMethod(nameof(Il2CppObjectBase.CreateGCHandle), BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+    private static void EmitCtorCall(ILGenerator il, Type type)
+    {
+        if (type.GetConstructor(new[] { typeof(IntPtr) }) is { } pointerConstructor)
+        {
+            // Base case: Il2Cpp constructor => call it directly
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Newobj, pointerConstructor);
+        }
+        else
+        {
+            // Special case: We have a parameterless constructor
+            // However, it could be be user-made or implicit
+            // In that case we set the GCHandle and then call the ctor and let GC destroy any objects created by DerivedConstructorPointer
+
+            // var obj = (T)RuntimeHelpers.GetUninitializedObject(type);
+            il.Emit(OpCodes.Ldtoken, type);
+            il.Emit(OpCodes.Call, _getTypeFromHandle);
+            il.Emit(OpCodes.Call, _getUninitializedObject);
+            il.Emit(OpCodes.Castclass, type);
+
+            // obj.CreateGCHandle(pointer);
+            il.Emit(OpCodes.Dup);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Call, _createGCHandle);
+
+            var parameterlessConstructor = type.GetConstructor(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, Type.EmptyTypes);
+            if (parameterlessConstructor != null)
+            {
+                // obj..ctor();
+                il.Emit(OpCodes.Dup);
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Callvirt, parameterlessConstructor);
+            }
+        }
+    }
+
+
+    internal static void EmitInjectedInitialization(ILGenerator il, Type type, FieldInfo[] fieldsToInitialize)
+    {
+        EmitFieldInitialization(il, type, fieldsToInitialize);
+        EmitGCHandling(il, type, false);
+    }
+
+    private static readonly MethodInfo _internWeak = typeof(Il2CppObjectPool).GetMethod(nameof(Il2CppObjectPool.InternWeak))!;
+    private static readonly MethodInfo _glue = typeof(Il2CppFinalizers).GetMethod(nameof(Il2CppFinalizers.FinalizerGlue), BindingFlags.NonPublic | BindingFlags.Static)!;
+
+    private static void EmitGCHandling(ILGenerator il, Type type, bool useGlue)
+    {
+        if (useGlue && ClassInjector.IsTypeManuallyFinalizable(type))
+        {
+            il.Emit(OpCodes.Dup);
+            il.Emit(OpCodes.Call, _internWeak);
+            il.Emit(OpCodes.Call, _glue);
+        }
+        else
+        {
+            il.Emit(OpCodes.Call, _internWeak);
+        }
+    }
+
+    private static void EmitFieldInitialization(ILGenerator il, Type type, FieldInfo[] fieldsToInitialize)
+    {
+        foreach (var field in fieldsToInitialize)
+        {
+            il.Emit(OpCodes.Dup);
+            il.Emit(OpCodes.Dup);
+            il.Emit(OpCodes.Ldstr, field.Name);
+            il.Emit(OpCodes.Newobj, field.FieldType.GetConstructor(
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, null,
+                new[] { typeof(Il2CppObjectBase), typeof(string) }, Array.Empty<ParameterModifier>())!
+            );
+            il.Emit(OpCodes.Stfld, field);
+        }
+    }
+
+    private static readonly Type[] _intPtrTypeArray = { typeof(IntPtr) };
+
+    private static class InitializerStore<T>
+    {
+        public delegate T Initializer(IntPtr pointer);
+
+        public static Initializer? initialize;
+        public static Initializer? initializeWithoutGlue;
+        public static Initializer Initialize => initialize ??= Create(true);
+        public static Initializer InitializeWithoutGlue => initializeWithoutGlue ??= Create(false);
+
+        private static Initializer Create(bool useGlue)
+        {
+            var type = Il2CppClassPointerStore<T>.CreatedTypeRedirect ?? typeof(T);
+
+            var fieldsToInitialize = type
+                .GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+                .Where(ClassInjector.IsFieldEligible)
+                .ToArray();
+
+            string methodName = useGlue ? "Initialize" : "InitializeWithoutGlue";
+            var dynamicMethod = new DynamicMethod($"{methodName}<{typeof(T).AssemblyQualifiedName}>", type, _intPtrTypeArray);
+            dynamicMethod.DefineParameter(0, ParameterAttributes.None, "pointer");
+
+            var il = dynamicMethod.GetILGenerator();
+            EmitCtorCall(il, type);
+            EmitFieldInitialization(il, type, fieldsToInitialize);
+            il.Emit(OpCodes.Dup);
+            EmitGCHandling(il, type, useGlue);
+            il.Emit(OpCodes.Ret);
+
+            return dynamicMethod.CreateDelegate<Initializer>();
+        }
+    }
+}
+
+// NB: Since a managed object might be garbage collected before its unmanaged counterpart is ready,
+//     we need another object (this one) to handle the cleanup.
+//     The objects' lifetimes are linked by the s_finalizers ephemeron on Il2CppFinalizers.
+internal class FinalizerContainer
+{
+    public nint gcHandle;
+    public IntPtr ptr;
+
+    ~FinalizerContainer()
+    {
+        Il2CppObjectPool.Free(gcHandle, ptr);
+    }
+}
+
+internal static class Il2CppFinalizers
+{
+    internal static readonly ConcurrentDictionary<IntPtr, byte> s_dying = new();
+    internal static readonly ConditionalWeakTable<Il2CppObjectBase, FinalizerContainer> s_ephemeron = new();
+
+    internal static void RunFinalizer<T>(IntPtr ptr) where T : Il2CppObjectBase
+    {
+        T ephemeral = Il2CppObjectInitializer.NewWithoutGlue<T>(ptr);
+        Action<T> finalize = (Action<T>)ClassInjector.ManualFinalizeCache[typeof(T)];
+        finalize(ephemeral);
+        GC.SuppressFinalize(ephemeral);
+    }
+
+    internal static void FinalizerGlue(Il2CppObjectBase obj)
+    {
+        s_ephemeron.Add(obj, obj.CreateFinalizerContainer());
+        obj.finalizerState = Il2CppObjectFinalizerState.Glued;
+        GC.SuppressFinalize(obj);
+    }
+}
+


### PR DESCRIPTION
- New way to track instances of injected classes, allowing injected finalizers to run properly, and fix the memory leaks which the documentation warns of.
- Consolidate Il2CppObjectBase initialization (and related IL generation) into one cohesive method.
- See [the new documentation](https://github.com/BepInEx/Il2CppInterop/blob/4d87b31f88be964d74012ddab07f7ccd59145506/Documentation/Class-Injection.md#garbage-collection) for the procedural overview.
- This also fixes a bug/is a breaking change: the lifetime of managed injected instances is now shorter, meaning that non-injected fields might now be dropped earlier than expected.~
- Open question: currently, this PR has some trickery to make the managed object's finalizer itself (`~Foo()`) be the method which is overriden, should we instead make this some `public override void Il2CppFinalize()` dummy method instead? It likely would make our implementation burden a little easier, and maybe elide the `SuppressFinalize` trickery, but would be an ergonomics hit.