### PR TITLE
fix crash when resolving types with non-ansi names

### DIFF
--- a/Il2CppInterop.Runtime/IL2CPP.cs
+++ b/Il2CppInterop.Runtime/IL2CPP.cs
@@ -236,7 +236,7 @@ public static unsafe class IL2CPP
         }
 
         while ((nestedTypePtr = il2cpp_class_get_nested_types(enclosingType, ref iter)) != IntPtr.Zero)
-            if (Marshal.PtrToStringAnsi(il2cpp_class_get_name(nestedTypePtr)) == nestedTypeName)
+            if (Marshal.PtrToStringUTF8(il2cpp_class_get_name(nestedTypePtr)) == nestedTypeName)
                 return nestedTypePtr;
 
         Logger.Instance.LogError(


### PR DESCRIPTION
In a previous pull request I had already worked around this by loading all FFI strings as System.String.
I've run into this issue again and reimplemented this part from the PR: https://github.com/BepInEx/Il2CppInterop/pull/110/commits/6a7afa12a1c85b23b9f15ab5f23c428bae9e7d39

This seems to be the only critical part it seems. If this resolve fails, the NativeClassPtr is null and other parts of the code will dereference it without checking.