### PR TITLE
Fix XrefScanUtilFinder for 32 bit games

### DIFF
--- a/Il2CppInterop.Common/XrefScans/XrefScanUtilFinder.cs
+++ b/Il2CppInterop.Common/XrefScans/XrefScanUtilFinder.cs
@@ -72,7 +72,7 @@ internal static class XrefScanUtilFinder
             if (instruction.Mnemonic == Mnemonic.Mov && seenCall)
                 if (instruction.Op0Kind == OpKind.Memory && (instruction.MemorySize == MemorySize.Int8 ||
                                                              instruction.MemorySize == MemorySize.UInt8))
-                    return ConvertUlongToIntPtr(instruction.IPRelativeMemoryAddress);
+                    return unchecked((IntPtr)instruction.IPRelativeMemoryAddress);
         }
     }
 

--- a/Il2CppInterop.Common/XrefScans/XrefScanUtilFinder.cs
+++ b/Il2CppInterop.Common/XrefScans/XrefScanUtilFinder.cs
@@ -34,7 +34,7 @@ internal static class XrefScanUtilFinder
                 if (instruction.Op0Kind == OpKind.Register && instruction.Op0Register == Register.ECX &&
                     instruction.Op1Kind == OpKind.Memory && instruction.IsIPRelativeMemoryOperand)
                 {
-                    var movTarget = (IntPtr)instruction.IPRelativeMemoryAddress;
+                    var movTarget = new IntPtr(unchecked((long)instruction.IPRelativeMemoryAddress));
                     if (instruction.MemorySize != MemorySize.UInt32 && instruction.MemorySize != MemorySize.Int32)
                         continue;
 
@@ -72,7 +72,7 @@ internal static class XrefScanUtilFinder
             if (instruction.Mnemonic == Mnemonic.Mov && seenCall)
                 if (instruction.Op0Kind == OpKind.Memory && (instruction.MemorySize == MemorySize.Int8 ||
                                                              instruction.MemorySize == MemorySize.UInt8))
-                    return (IntPtr)instruction.IPRelativeMemoryAddress;
+                    return new IntPtr(unchecked((long)instruction.IPRelativeMemoryAddress));
         }
     }
 

--- a/Il2CppInterop.Common/XrefScans/XrefScanUtilFinder.cs
+++ b/Il2CppInterop.Common/XrefScans/XrefScanUtilFinder.cs
@@ -94,10 +94,4 @@ internal static class XrefScanUtilFinder
                 return 0;
         }
     }
-
-    private static IntPtr ConvertUlongToIntPtr(ulong address)
-    {
-        if (Environment.Is64BitProcess) return address <= long.MaxValue ? new IntPtr((long)address) : new IntPtr(unchecked((long)address));
-        else return address <= int.MaxValue ? new IntPtr((int)address) : new IntPtr(unchecked((int)address));
-    }
 }

--- a/Il2CppInterop.Common/XrefScans/XrefScanUtilFinder.cs
+++ b/Il2CppInterop.Common/XrefScans/XrefScanUtilFinder.cs
@@ -34,7 +34,7 @@ internal static class XrefScanUtilFinder
                 if (instruction.Op0Kind == OpKind.Register && instruction.Op0Register == Register.ECX &&
                     instruction.Op1Kind == OpKind.Memory && instruction.IsIPRelativeMemoryOperand)
                 {
-                    var movTarget = ConvertUlongToIntPtr(instruction.IPRelativeMemoryAddress);
+                    var movTarget = unchecked((IntPtr)instruction.IPRelativeMemoryAddress);
                     if (instruction.MemorySize != MemorySize.UInt32 && instruction.MemorySize != MemorySize.Int32)
                         continue;
 

--- a/Il2CppInterop.Common/XrefScans/XrefScanUtilFinder.cs
+++ b/Il2CppInterop.Common/XrefScans/XrefScanUtilFinder.cs
@@ -34,7 +34,7 @@ internal static class XrefScanUtilFinder
                 if (instruction.Op0Kind == OpKind.Register && instruction.Op0Register == Register.ECX &&
                     instruction.Op1Kind == OpKind.Memory && instruction.IsIPRelativeMemoryOperand)
                 {
-                    var movTarget = new IntPtr(unchecked((long)instruction.IPRelativeMemoryAddress));
+                    var movTarget = ConvertUlongToIntPtr(instruction.IPRelativeMemoryAddress);
                     if (instruction.MemorySize != MemorySize.UInt32 && instruction.MemorySize != MemorySize.Int32)
                         continue;
 
@@ -72,7 +72,7 @@ internal static class XrefScanUtilFinder
             if (instruction.Mnemonic == Mnemonic.Mov && seenCall)
                 if (instruction.Op0Kind == OpKind.Memory && (instruction.MemorySize == MemorySize.Int8 ||
                                                              instruction.MemorySize == MemorySize.UInt8))
-                    return new IntPtr(unchecked((long)instruction.IPRelativeMemoryAddress));
+                    return ConvertUlongToIntPtr(instruction.IPRelativeMemoryAddress);
         }
     }
 
@@ -93,5 +93,11 @@ internal static class XrefScanUtilFinder
             default:
                 return 0;
         }
+    }
+
+    private static IntPtr ConvertUlongToIntPtr(ulong address)
+    {
+        if (Environment.Is64BitProcess) return address <= long.MaxValue ? new IntPtr((long)address) : new IntPtr(unchecked((long)address));
+        else return address <= int.MaxValue ? new IntPtr((int)address) : new IntPtr(unchecked((int)address));
     }
 }


### PR DESCRIPTION
It tried to convert IPRelativeMemoryAddress to IntPtr and that caused OverflowException on 32 bit games when the value exceeded int.MaxValue.