### PR TITLE
Fix "Handle is not initialized" for Unity 2021.2.x games

### DIFF
--- a/Il2CppInterop.Runtime/Runtime/ClassInjectorBase.cs
+++ b/Il2CppInterop.Runtime/Runtime/ClassInjectorBase.cs
@@ -26,8 +26,6 @@ public static class ClassInjectorBase
     /// Tries to get the Garbage collector pointer from the m_target object from the m_target of the delegate.
     /// Fixes Harmony in Unity 2021.2.x .
     /// </summary>
-    /// <param name="pointer"></param>
-    /// <returns></returns>
     private static IntPtr FallbackGetGcHandlePtrFromIl2CppDelegateMTarget(IntPtr pointer)
     {
         if (IL2CPP.il2cpp_class_is_assignable_from(Il2CppClassPointerStore<Il2CppSystem.MulticastDelegate>.NativeClassPtr, IL2CPP.il2cpp_object_get_class(pointer)))


### PR DESCRIPTION
This is a fix proposal for #210 - I was trying to work with Neptunia Sisters Vs Sisters which is affected by the same issue the user reported there.  
  
When the mono object is a System.Action object it seems `GetGcHandlePtrFromIl2CppObject(pointer)` returns a null pointer for the Garbage Collector Handle (or well IntPtr.Zero). This causes `GCHandle.FromIntPtr(gcHandle)` to throw an excepction.  
  
One solution after a lot of back and forth was to essentially check if the object class is a Delegate type class (which includes System.Action) and if so, get the garbage collector handle on the mTarget of the delegate object. This way in my testing the code will not interfere with other Unity versions - yet it allows to hook onto my test game - which happens to be a 2021.2.x game compiled with IL2CPP.  
  
In other Unity versions `if (gcHandle == IntPtr.Zero)` should be false so I doubt this would interfere in any way (it worked fine in other tested games for me).