### PR TITLE
Added better support for nested classes in GetIl2CppTypeFullName method.

### DIFF
--- a/Il2CppInterop.Runtime/Injection/ClassInjector.cs
+++ b/Il2CppInterop.Runtime/Injection/ClassInjector.cs
@@ -1116,12 +1116,12 @@ public static unsafe partial class ClassInjector
         var klass = UnityVersionHandler.Wrap((Il2CppClass*)IL2CPP.il2cpp_class_from_type((IntPtr)typePointer));
         var assembly = UnityVersionHandler.Wrap(UnityVersionHandler.Wrap(klass.Image).Assembly);
         var fullName = new StringBuilder();
-        var names = new List<string>();
+        var names = new Stack<string>();
         var declaringType = klass;
         var outerType = klass;
         do
         {
-            names.Add(Marshal.PtrToStringUTF8(declaringType.Name) ?? "");
+            names.Push(Marshal.PtrToStringUTF8(declaringType.Name) ?? "");
             outerType = declaringType;
         }
         while ((declaringType = UnityVersionHandler.Wrap(declaringType.DeclaringType)) != default);
@@ -1129,7 +1129,6 @@ public static unsafe partial class ClassInjector
 
         fullName.Append(namespaceName);
         fullName.Append('.');
-        names.Reverse();
         fullName.Append(string.Join("+", names));
 
         var assemblyName = Marshal.PtrToStringUTF8(assembly.Name.Name);

--- a/Il2CppInterop.Runtime/Injection/ClassInjector.cs
+++ b/Il2CppInterop.Runtime/Injection/ClassInjector.cs
@@ -1115,24 +1115,22 @@ public static unsafe partial class ClassInjector
     {
         var klass = UnityVersionHandler.Wrap((Il2CppClass*)IL2CPP.il2cpp_class_from_type((IntPtr)typePointer));
         var assembly = UnityVersionHandler.Wrap(UnityVersionHandler.Wrap(klass.Image).Assembly);
-
         var fullName = new StringBuilder();
-
-        var namespaceName = Marshal.PtrToStringUTF8(klass.Namespace);
-        if (!string.IsNullOrEmpty(namespaceName))
-        {
-            fullName.Append(namespaceName);
-            fullName.Append('.');
-        }
-
+        var names = new List<string>();
         var declaringType = klass;
-        while ((declaringType = UnityVersionHandler.Wrap(declaringType.DeclaringType)) != default)
+        var outerType = klass;
+        do
         {
-            fullName.Append(Marshal.PtrToStringUTF8(declaringType.Name));
-            fullName.Append('+');
+            names.Add(Marshal.PtrToStringUTF8(declaringType.Name) ?? "");
+            outerType = declaringType;
         }
+        while ((declaringType = UnityVersionHandler.Wrap(declaringType.DeclaringType)) != default);
+        var namespaceName = outerType.Namespace != IntPtr.Zero ? Marshal.PtrToStringUTF8(outerType.Namespace) ?? "" : "";
 
-        fullName.Append(Marshal.PtrToStringUTF8(klass.Name));
+        fullName.Append(namespaceName);
+        fullName.Append('.');
+        names.Reverse();
+        fullName.Append(string.Join("+", names));
 
         var assemblyName = Marshal.PtrToStringUTF8(assembly.Name.Name);
         if (assemblyName != "mscorlib")

--- a/Il2CppInterop.Runtime/Injection/ClassInjector.cs
+++ b/Il2CppInterop.Runtime/Injection/ClassInjector.cs
@@ -1128,7 +1128,8 @@ public static unsafe partial class ClassInjector
         var namespaceName = outerType.Namespace != IntPtr.Zero ? Marshal.PtrToStringUTF8(outerType.Namespace) ?? "" : "";
 
         fullName.Append(namespaceName);
-        fullName.Append('.');
+        if (namespaceName.Length > 0)
+            fullName.Append('.');
         fullName.Append(string.Join("+", names));
 
         var assemblyName = Marshal.PtrToStringUTF8(assembly.Name.Name);


### PR DESCRIPTION
Previous implementation was unable to find the namespace of nested il2cpp classes.  Causing the "Couldn't find System.Type for Il2Cpp type" error.

I modified the loop to get the namespace from the outermost class.  
I also fixed a bug where the nest class names would be in reverse order.