### PR TITLE
Fixed nested classes in AddTypeToLookup

### DIFF
--- a/Il2CppInterop.Runtime/Injection/InjectorHelpers.cs
+++ b/Il2CppInterop.Runtime/Injection/InjectorHelpers.cs
@@ -91,9 +91,9 @@ namespace Il2CppInterop.Runtime.Injection
         internal static void AddTypeToLookup<T>(IntPtr typePointer) where T : class => AddTypeToLookup(typeof(T), typePointer);
         internal static void AddTypeToLookup(Type type, IntPtr typePointer)
         {
-            string klass = type.Name;
-            if (klass == null) return;
-            string namespaze = type.Namespace ?? string.Empty;
+            string klass = ClassInjector.GetTypeName(type, ClassInjector.Il2CppTypeNameOptions.Name);
+            if (klass.Length == 0) return;
+            string namespaze = ClassInjector.GetTypeName(type, ClassInjector.Il2CppTypeNameOptions.Namespace);
             var attribute = Attribute.GetCustomAttribute(type, typeof(Il2CppInterop.Runtime.Attributes.ClassInjectionAssemblyTargetAttribute)) as Il2CppInterop.Runtime.Attributes.ClassInjectionAssemblyTargetAttribute;
 
             foreach (IntPtr image in (attribute is null) ? IL2CPP.GetIl2CppImages() : attribute.GetImagePointers())


### PR DESCRIPTION
In some situations `AddTypeToLookup` would fail with nested classes, it would not get the full name properly.  

I added a `ClassInjector.GetTypeName` method very similar to `ClassInjector.GetIl2CppTypeFullName` that accepts a enum for what parts of the name you want.  Might not be the cleanest way to do it, especially considering it's only used in one place atm.  But could be useful.  Could also add that enum field to GetIl2CppTypeFullName, though not sure where you'd need that.

These two changes together make it so that it doesn't try to double up on lookup keys in some cases with nested classes.