### PR TITLE
Implement Managed Detour in Il2CppDetourMethodPatcher

### DIFF
--- a/Il2CppInterop.HarmonySupport/Il2CppDetourMethodPatcher.cs
+++ b/Il2CppInterop.HarmonySupport/Il2CppDetourMethodPatcher.cs
@@ -12,9 +12,10 @@ using Il2CppInterop.Runtime.Runtime.VersionSpecific.MethodInfo;
 using Il2CppInterop.Runtime.Startup;
 using Microsoft.Extensions.Logging;
 using MonoMod.Cil;
+using MonoMod.RuntimeDetour;
 using MonoMod.Utils;
+using IDetour = Il2CppInterop.Runtime.Injection.IDetour;
 using ValueType = Il2CppSystem.ValueType;
-using Void = Il2CppSystem.Void;
 
 namespace Il2CppInterop.HarmonySupport;
 
@@ -57,6 +58,8 @@ internal unsafe class Il2CppDetourMethodPatcher : MethodPatcher
     };
 
     private static readonly List<object> DelegateCache = new();
+    private static readonly List<object> ILHookCache = new();
+
     private INativeMethodInfoStruct modifiedNativeMethodInfo;
 
     private IDetour nativeDetour;
@@ -147,8 +150,39 @@ internal unsafe class Il2CppDetourMethodPatcher : MethodPatcher
         nativeDetour.Apply();
         modifiedNativeMethodInfo.MethodPointer = nativeDetour.OriginalTrampoline;
 
-        // TODO: Add an ILHook for the original unhollowed method to go directly to managedHookedMethod
-        // Right now it goes through three times as much interop conversion as it needs to, when being called from managed side
+        var ilHook = new ILHook(Original, Manipulator);
+        ilHook.Apply();
+
+        ILHookCache.Add(ilHook);
+
+        void Manipulator(ILContext il)
+        {
+            il.Body.Instructions.Clear();
+            il.Body.ExceptionHandlers.Clear();
+            il.Body.Variables.Clear();
+
+            var c = new ILCursor(il);
+
+            var isStatic = (Original as MethodInfo)?.IsStatic ?? false;
+            var paramCount = Original.GetParameters().Length + (isStatic ? 0 : 1);
+
+            for (var i = 0; i < paramCount; i++)
+            {
+                c.Emit(Mono.Cecil.Cil.OpCodes.Ldarg, i);
+            }
+
+            var target = il.Module.ImportReference(managedHookedMethod);
+
+            var callOp = managedHookedMethod.IsVirtual && !managedHookedMethod.IsStatic
+                ? Mono.Cecil.Cil.OpCodes.Callvirt
+                : Mono.Cecil.Cil.OpCodes.Call;
+
+            c.Emit(callOp, target);
+            c.Emit(Mono.Cecil.Cil.OpCodes.Ret);
+
+            il.Body.MaxStackSize = paramCount + 1;
+        }
+
         return managedHookedMethod;
     }
 


### PR DESCRIPTION
Calling a game function in managed code should directly invoke the managed hook if one exists. This PR implements an IL Hook in the interop/unhollowed function to run the managed hook directly instead of first invoking the IL2CPP function, which returns back to managed code anyways (when there is a hook installed).

Someone should probably double-check my IL, even though this code worked fine when I tested it.