### PR TITLE
Update Il2CppInterop.Runtime for Unity 6 and above IL2Cpp support

### DIFF
--- a/Il2CppInterop.Runtime/Injection/Hooks/GenericMethod_GetMethod_Hook.cs
+++ b/Il2CppInterop.Runtime/Injection/Hooks/GenericMethod_GetMethod_Hook.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Runtime.InteropServices;
 using Il2CppInterop.Common;
@@ -19,6 +19,9 @@ namespace Il2CppInterop.Runtime.Injection.Hooks
 
         private Il2CppMethodInfo* Hook(Il2CppGenericMethod* gmethod, bool copyMethodPtr)
         {
+            if (gmethod == null || gmethod->methodDefinition == null)
+                return Original(gmethod, copyMethodPtr);
+
             if (ClassInjector.InflatedMethodFromContextDictionary.TryGetValue((IntPtr)gmethod->methodDefinition, out var methods))
             {
                 var instancePointer = gmethod->context.method_inst;
@@ -53,8 +56,6 @@ namespace Il2CppInterop.Runtime.Injection.Hooks
 
         public override IntPtr FindTargetMethod()
         {
-            // On Unity 2021.2+, the 3 parameter shim can be inlined and optimized by the compiler
-            // which moves the method we're looking for
             var genericMethodGetMethod = s_Signatures
                 .Select(s => MemoryUtils.FindSignatureInModule(InjectorHelpers.Il2CppModule, s))
                 .FirstOrDefault(p => p != 0);

--- a/Il2CppInterop.Runtime/Injection/Hooks/GenericMethod_GetMethod_Hook.cs
+++ b/Il2CppInterop.Runtime/Injection/Hooks/GenericMethod_GetMethod_Hook.cs
@@ -54,6 +54,9 @@ namespace Il2CppInterop.Runtime.Injection.Hooks
             }
         };
 
+        // Compilers might change method location (Unity 2021.2+)
+        // We do a signature scan to find the correct method
+
         public override IntPtr FindTargetMethod()
         {
             var genericMethodGetMethod = s_Signatures

--- a/Il2CppInterop.Runtime/Injection/Hooks/GenericMethod_GetMethod_Unity6_Hook.cs
+++ b/Il2CppInterop.Runtime/Injection/Hooks/GenericMethod_GetMethod_Unity6_Hook.cs
@@ -7,8 +7,6 @@ using Il2CppInterop.Runtime.Runtime;
 using Il2CppInterop.Runtime.Startup;
 using Microsoft.Extensions.Logging;
 
-// hello :)
-
 namespace Il2CppInterop.Runtime.Injection.Hooks
 {
     /// Unity 6 (6000.x.x): the 1-param GetMethod(const Il2CppGenericMethod&amp;) is inlined into

--- a/Il2CppInterop.Runtime/Injection/Hooks/GenericMethod_GetMethod_Unity6_Hook.cs
+++ b/Il2CppInterop.Runtime/Injection/Hooks/GenericMethod_GetMethod_Unity6_Hook.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Il2CppInterop.Common;
+using Il2CppInterop.Common.XrefScans;
+using Il2CppInterop.Runtime.Runtime;
+using Il2CppInterop.Runtime.Startup;
+using Microsoft.Extensions.Logging;
+
+// hello :)
+
+namespace Il2CppInterop.Runtime.Injection.Hooks
+{
+    /// Unity 6 (6000.x.x): the 1-param GetMethod(const Il2CppGenericMethod&amp;) is inlined into
+    /// the 3-param GetMethod(const MethodInfo*, const Il2CppGenericInst*, const Il2CppGenericInst*).
+    /// We use the hook with 3 param correctly
+    internal unsafe class GenericMethod_GetMethod_Unity6_Hook : Hook<GenericMethod_GetMethod_Unity6_Hook.MethodDelegate>
+    {
+        public override string TargetMethodName => "GenericMethod::GetMethod";
+        public override MethodDelegate GetDetour() => Hook;
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        internal delegate Il2CppMethodInfo* MethodDelegate(Il2CppMethodInfo* methodDefinition, Il2CppGenericInst* classInst, Il2CppGenericInst* methodInst);
+
+        private Il2CppMethodInfo* Hook(Il2CppMethodInfo* methodDefinition, Il2CppGenericInst* classInst, Il2CppGenericInst* methodInst)
+        {
+            if (methodDefinition == null)
+                return Original(methodDefinition, classInst, methodInst);
+
+            if (ClassInjector.InflatedMethodFromContextDictionary.TryGetValue((IntPtr)methodDefinition, out var methods))
+            {
+                if (methodInst == null)
+                    return Original(methodDefinition, classInst, methodInst);
+
+                if (methods.Item2.TryGetValue((IntPtr)methodInst, out var inflatedMethodPointer))
+                    return (Il2CppMethodInfo*)inflatedMethodPointer;
+
+                var typeArguments = new Type[methodInst->type_argc];
+                for (var i = 0; i < methodInst->type_argc; i++)
+                    typeArguments[i] = ClassInjector.SystemTypeFromIl2CppType(methodInst->type_argv[i]);
+                var inflatedMethod = methods.Item1.MakeGenericMethod(typeArguments);
+                Logger.Instance.LogTrace("Inflated method: {InflatedMethod}", inflatedMethod.Name);
+                inflatedMethodPointer = (IntPtr)ClassInjector.ConvertMethodInfo(inflatedMethod,
+                    UnityVersionHandler.Wrap(UnityVersionHandler.Wrap(methodDefinition).Class));
+                methods.Item2.Add((IntPtr)methodInst, inflatedMethodPointer);
+
+                return (Il2CppMethodInfo*)inflatedMethodPointer;
+            }
+
+            return Original(methodDefinition, classInst, methodInst);
+        }
+
+        public override IntPtr FindTargetMethod()
+        {
+            var getVirtualMethodAPI = InjectorHelpers.GetIl2CppExport(nameof(IL2CPP.il2cpp_object_get_virtual_method));
+
+            var getVirtualMethod = XrefScannerLowLevel.JumpTargets(getVirtualMethodAPI).Single();
+
+            var getVirtualMethodXrefs = XrefScannerLowLevel.JumpTargets(getVirtualMethod).ToArray();
+            if (getVirtualMethodXrefs.Length == 0)
+                return IntPtr.Zero;
+
+            // Last xref from Object::GetVirtualMethod is GetGenericVirtualMethod
+            var getGenericVirtualMethod = getVirtualMethodXrefs.Last();
+
+            // GetGenericVirtualMethod has a single tail-JMP to GetMethod(3 params)
+            var shimXrefs = XrefScannerLowLevel.JumpTargets(getGenericVirtualMethod).ToArray();
+            if (shimXrefs.Length == 0)
+                return IntPtr.Zero;
+
+            return shimXrefs.Take(2).Last();
+        }
+    }
+}

--- a/Il2CppInterop.Runtime/Injection/InjectorHelpers.cs
+++ b/Il2CppInterop.Runtime/Injection/InjectorHelpers.cs
@@ -63,7 +63,7 @@ namespace Il2CppInterop.Runtime.Injection
         }
 
         private static readonly GenericMethod_GetMethod_Hook GenericMethodGetMethodHook = new();
-        private static readonly GenericMethod_GetMethod_Unity6_Hook GenericMethodGetMethodUnity6Hook = new();
+        private static readonly GenericMethod_GetMethod_Unity6_Hook GenericMethodGetMethodHook_Unity6 = new();
         private static readonly MetadataCache_GetTypeInfoFromTypeDefinitionIndex_Hook GetTypeInfoFromTypeDefinitionIndexHook = new();
         private static readonly Class_GetFieldDefaultValue_Hook GetFieldDefaultValueHook = new();
         private static readonly Class_FromIl2CppType_Hook FromIl2CppTypeHook = new();

--- a/Il2CppInterop.Runtime/Injection/InjectorHelpers.cs
+++ b/Il2CppInterop.Runtime/Injection/InjectorHelpers.cs
@@ -72,7 +72,7 @@ namespace Il2CppInterop.Runtime.Injection
         {
             if (InjectedAssembly == null) CreateInjectedAssembly();
             if (Il2CppInteropRuntime.Instance.UnityVersion.Major >= 6000)
-                GenericMethodGetMethodUnity6Hook.ApplyHook();
+                GenericMethodGetMethodHook_Unity6.ApplyHook();
             else
                 GenericMethodGetMethodHook.ApplyHook();
             GetTypeInfoFromTypeDefinitionIndexHook.ApplyHook();

--- a/Il2CppInterop.Runtime/Injection/InjectorHelpers.cs
+++ b/Il2CppInterop.Runtime/Injection/InjectorHelpers.cs
@@ -63,6 +63,7 @@ namespace Il2CppInterop.Runtime.Injection
         }
 
         private static readonly GenericMethod_GetMethod_Hook GenericMethodGetMethodHook = new();
+        private static readonly GenericMethod_GetMethod_Unity6_Hook GenericMethodGetMethodUnity6Hook = new();
         private static readonly MetadataCache_GetTypeInfoFromTypeDefinitionIndex_Hook GetTypeInfoFromTypeDefinitionIndexHook = new();
         private static readonly Class_GetFieldDefaultValue_Hook GetFieldDefaultValueHook = new();
         private static readonly Class_FromIl2CppType_Hook FromIl2CppTypeHook = new();
@@ -70,7 +71,10 @@ namespace Il2CppInterop.Runtime.Injection
         internal static void Setup()
         {
             if (InjectedAssembly == null) CreateInjectedAssembly();
-            GenericMethodGetMethodHook.ApplyHook();
+            if (Il2CppInteropRuntime.Instance.UnityVersion.Major >= 6000)
+                GenericMethodGetMethodUnity6Hook.ApplyHook();
+            else
+                GenericMethodGetMethodHook.ApplyHook();
             GetTypeInfoFromTypeDefinitionIndexHook.ApplyHook();
             GetFieldDefaultValueHook.ApplyHook();
             ClassInit ??= FindClassInit();


### PR DESCRIPTION
Updated Il2CppInterop.Runtime to have proper hooks for metadata v39 and Unity 6000
This requires https://github.com/BepInEx/Il2CppInterop/pull/254 aswell