### PR TITLE
Fix DelegateSupport return type conversions

### DIFF
--- a/Il2CppInterop.Runtime/DelegateSupport.cs
+++ b/Il2CppInterop.Runtime/DelegateSupport.cs
@@ -163,11 +163,11 @@ public static class DelegateSupport
 
         bodyBuilder.Emit(OpCodes.Call, managedMethod);
 
-        if (returnType == typeof(string))
+        if (managedMethod.ReturnType == typeof(string))
         {
             bodyBuilder.Emit(OpCodes.Call, typeof(IL2CPP).GetMethod(nameof(IL2CPP.ManagedStringToIl2Cpp))!);
         }
-        else if (!returnType.IsValueType)
+        else if (!managedMethod.ReturnType.IsValueType)
         {
             var labelNull = bodyBuilder.DefineLabel();
             var labelDone = bodyBuilder.DefineLabel();


### PR DESCRIPTION
Delegates which return a il2cpp object or string would have an invalid IL error because interop checks the native type and not the managed type, and thus no conversions are done