### PR TITLE
fix: preserve Nullable<T> data in Harmony patches

### DIFF
--- a/Il2CppInterop.HarmonySupport/Il2CppDetourMethodPatcher.cs
+++ b/Il2CppInterop.HarmonySupport/Il2CppDetourMethodPatcher.cs
@@ -385,7 +385,7 @@ internal unsafe class Il2CppDetourMethodPatcher : MethodPatcher
             // il2cpp_value_box uses .NET boxing semantics which boxes Nullable<T> as just T,
             // losing the HasValue field. Manually box Nullable<T> to preserve full data.
             bool isNullable = managedParamType.IsGenericType &&
-                managedParamType.GetGenericTypeDefinition().FullName?.Contains("Nullable`1") == true;
+                managedParamType.GetGenericTypeDefinition().FullName == "Il2CppSystem.Nullable`1";
 
             if (isNullable)
             {
@@ -397,19 +397,24 @@ internal unsafe class Il2CppDetourMethodPatcher : MethodPatcher
                 il.Emit(OpCodes.Call, AccessTools.Method(typeof(IL2CPP), nameof(IL2CPP.il2cpp_object_new)));
                 var objLocal = il.DeclareLocal(typeof(IntPtr));
                 il.Emit(OpCodes.Stloc, objLocal);
+                il.Emit(Environment.Is64BitProcess ? OpCodes.Ldarg : OpCodes.Ldarga_S, argIndex);
                 il.Emit(OpCodes.Ldloc, objLocal);
                 il.Emit(OpCodes.Call, AccessTools.Method(typeof(IL2CPP), nameof(IL2CPP.il2cpp_object_unbox)));
-                il.Emit(Environment.Is64BitProcess ? OpCodes.Ldarg : OpCodes.Ldarga_S, argIndex);
                 il.Emit(OpCodes.Ldc_I4, (int)valueSize);
                 il.Emit(OpCodes.Call, AccessTools.Method(typeof(Il2CppDetourMethodPatcher), nameof(CopyMemory)));
                 il.Emit(OpCodes.Ldloc, objLocal);
             }
             else
             {
+                // Box struct into object first before conversion
                 il.Emit(OpCodes.Ldc_I8, classPtr.ToInt64());
                 il.Emit(OpCodes.Conv_I);
+                // On x64, struct is always a pointer but it is a non-pointer on x86
+                // We don't handle byref structs on x86 yet but we're yet to encounter those
                 il.Emit(Environment.Is64BitProcess ? OpCodes.Ldarg : OpCodes.Ldarga_S, argIndex);
-                il.Emit(OpCodes.Call, AccessTools.Method(typeof(IL2CPP), nameof(IL2CPP.il2cpp_value_box)));
+                il.Emit(OpCodes.Call,
+                    AccessTools.Method(typeof(IL2CPP),
+                        nameof(IL2CPP.il2cpp_value_box)));
             }
         }
         else
@@ -472,6 +477,6 @@ internal unsafe class Il2CppDetourMethodPatcher : MethodPatcher
         }
     }
 
-    private static void CopyMemory(IntPtr dest, IntPtr src, int size) =>
+    private static void CopyMemory(IntPtr src, IntPtr dest, int size) =>
         Buffer.MemoryCopy(src.ToPointer(), dest.ToPointer(), size, size);
 }

--- a/Il2CppInterop.HarmonySupport/Il2CppDetourMethodPatcher.cs
+++ b/Il2CppInterop.HarmonySupport/Il2CppDetourMethodPatcher.cs
@@ -376,17 +376,41 @@ internal unsafe class Il2CppDetourMethodPatcher : MethodPatcher
     {
         variable = null;
 
-        if (managedParamType.IsSubclassOf(typeof(ValueType)))
+        bool needsBoxing = managedParamType.IsSubclassOf(typeof(ValueType));
+
+        if (needsBoxing)
         {
-            // Box struct into object first before conversion
-            il.Emit(OpCodes.Ldc_I8, Il2CppClassPointerStore.GetNativeClassPointer(managedParamType).ToInt64());
-            il.Emit(OpCodes.Conv_I);
-            // On x64, struct is always a pointer but it is a non-pointer on x86
-            // We don't handle byref structs on x86 yet but we're yet to encounter those
-            il.Emit(Environment.Is64BitProcess ? OpCodes.Ldarg : OpCodes.Ldarga_S, argIndex);
-            il.Emit(OpCodes.Call,
-                AccessTools.Method(typeof(IL2CPP),
-                    nameof(IL2CPP.il2cpp_value_box)));
+            var classPtr = Il2CppClassPointerStore.GetNativeClassPointer(managedParamType);
+
+            // il2cpp_value_box uses .NET boxing semantics which boxes Nullable<T> as just T,
+            // losing the HasValue field. Manually box Nullable<T> to preserve full data.
+            bool isNullable = managedParamType.IsGenericType &&
+                managedParamType.GetGenericTypeDefinition().FullName?.Contains("Nullable`1") == true;
+
+            if (isNullable)
+            {
+                uint align = 0;
+                var valueSize = IL2CPP.il2cpp_class_value_size(classPtr, ref align);
+
+                il.Emit(OpCodes.Ldc_I8, classPtr.ToInt64());
+                il.Emit(OpCodes.Conv_I);
+                il.Emit(OpCodes.Call, AccessTools.Method(typeof(IL2CPP), nameof(IL2CPP.il2cpp_object_new)));
+                var objLocal = il.DeclareLocal(typeof(IntPtr));
+                il.Emit(OpCodes.Stloc, objLocal);
+                il.Emit(OpCodes.Ldloc, objLocal);
+                il.Emit(OpCodes.Call, AccessTools.Method(typeof(IL2CPP), nameof(IL2CPP.il2cpp_object_unbox)));
+                il.Emit(Environment.Is64BitProcess ? OpCodes.Ldarg : OpCodes.Ldarga_S, argIndex);
+                il.Emit(OpCodes.Ldc_I4, (int)valueSize);
+                il.Emit(OpCodes.Call, AccessTools.Method(typeof(Il2CppDetourMethodPatcher), nameof(CopyMemory)));
+                il.Emit(OpCodes.Ldloc, objLocal);
+            }
+            else
+            {
+                il.Emit(OpCodes.Ldc_I8, classPtr.ToInt64());
+                il.Emit(OpCodes.Conv_I);
+                il.Emit(Environment.Is64BitProcess ? OpCodes.Ldarg : OpCodes.Ldarga_S, argIndex);
+                il.Emit(OpCodes.Call, AccessTools.Method(typeof(IL2CPP), nameof(IL2CPP.il2cpp_value_box)));
+            }
         }
         else
         {
@@ -447,4 +471,7 @@ internal unsafe class Il2CppDetourMethodPatcher : MethodPatcher
             HandleTypeConversion(managedParamType);
         }
     }
+
+    private static void CopyMemory(IntPtr dest, IntPtr src, int size) =>
+        Buffer.MemoryCopy(src.ToPointer(), dest.ToPointer(), size, size);
 }


### PR DESCRIPTION
## Description

This PR attempts to fix the data corruption issue with `Nullable<T>` parameters in Harmony patch methods.

### Symptom

When a native IL2CPP method passes a `Nullable<T>` struct (e.g., `Nullable<Vector3>`) to a managed Harmony patch, the parameter data gets shifted by 4 bytes, causing field misalignment and garbage values in the struct.

Below is the IDA view showing the target parameter (stack space pointed to by register `R8`) before and after entering the patch for a function with a `Nullable<Vector3>` parameter. Notice how exactly 4 bytes representing `hasValue` are missing:


<img width="1223" height="693" alt="image-20260329232457305" src="https://github.com/user-attachments/assets/d9237ba2-eec3-4e55-a02e-d489c74e22f5" />


### Test Case

I created a dedicated Unity test project to reproduce and verify the fix using `Nullable<Vector3>` as an example. It includes the Unity project source code, test mod source code, IL2CppDumper-processed IDA database, and game executable with BepInEx containing this fix.

https://drive.google.com/file/d/1-1E6jZ3cem82Q_lthL1b3ulUHKtAllFT/view?usp=sharing

### Root Cause

`il2cpp_value_box` follows .NET boxing semantics — when `HasValue` is `true`, a `Nullable<T>` boxes to just `T`. This means only the `Value` field (offset 0x4) is copied while the `HasValue` field (offset 0x0) is discarded, resulting in the 4-byte data offset.

### Solution

For `Nullable<T>` types, bypass `il2cpp_value_box` and instead manually create an IL2CPP object using `il2cpp_object_new`, then copy the complete struct data (including `HasValue`) using `Buffer.MemoryCopy`.

### Verification

Tested with a `Nullable<Vector3>` parameter in a Harmony prefix patch. Before the fix, Vector3 values were corrupted; after the fix, all fields are correctly preserved.

Before fix — Harmony always corrupts `Nullable<T>`:

<img width="1389" height="389" alt="image-20260330030531520" src="https://github.com/user-attachments/assets/f6ff6b70-6378-433d-b0a7-deb0a0967363" />

After fix — Harmony correctly handles `Nullable<T>`:

<img width="1281" height="384" alt="image-20260330030434519" src="https://github.com/user-attachments/assets/e9725a86-8c96-463e-bfb9-fdcbe40966f9" />

I'm not certain this works for all `Nullable<T>` cases, but it has been verified in my mod project [MetaMikuAI/MetaMystia](https://github.com/MetaMikuAI/MetaMystia). If anyone urgently needs this fix, consider using my patched build at https://github.com/MetaMikuAI/Il2CppInterop/releases/tag/fix-nullable-patch-pr-259

I hope this test case and experimental fix can provide some insights.