### PR TITLE
fix: harden hook and signature resolution for optimized IL2CPP builds

### DIFF
--- a/Il2CppInterop.Runtime/Injection/Hooks/MetadataCache_GetTypeInfoFromTypeDefinitionIndex_Hook.cs
+++ b/Il2CppInterop.Runtime/Injection/Hooks/MetadataCache_GetTypeInfoFromTypeDefinitionIndex_Hook.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Runtime.InteropServices;
 using Il2CppInterop.Common;
@@ -75,8 +75,8 @@ namespace Il2CppInterop.Runtime.Injection.Hooks
                 else getTypeInfoFromTypeDefinitionIndex = imageGetTypeXrefs[0];
                 if ((getTypeInfoFromTypeDefinitionIndex.ToInt64() & 0xF) != 0)
                 {
-                    Logger.Instance.LogTrace("Image::GetType xref wasn't aligned, attempting to resolve from icall");
-                    return FindGetTypeInfoFromTypeDefinitionIndex(true);
+                    Logger.Instance.LogTrace("Image::GetType xref wasn't aligned, GetTypeInfoFromTypeDefinitionIndex is likely inlined into Image::GetType");
+                    getTypeInfoFromTypeDefinitionIndex = imageGetType;
                 }
                 if (imageGetTypeXrefs.Count() > 1 && UnityVersionHandler.IsMetadataV29OrHigher)
                 {

--- a/Il2CppInterop.Runtime/Injection/InjectorHelpers.cs
+++ b/Il2CppInterop.Runtime/Injection/InjectorHelpers.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -187,7 +187,7 @@ namespace Il2CppInterop.Runtime.Injection
             }
             nint pClassInit = s_ClassInitSignatures
                 .Select(s => MemoryUtils.FindSignatureInModule(Il2CppModule, s))
-                .FirstOrDefault(p => p != 0);
+                .FirstOrDefault(p => p != 0 && (long)p >= (long)Il2CppModule.BaseAddress && (long)p < (long)Il2CppModule.BaseAddress + Il2CppModule.ModuleMemorySize);
 
             if (pClassInit == 0)
             {


### PR DESCRIPTION
While trying to get [Resonite](https://store.steampowered.com/app/2519830/Resonite/)'s upcoming IL2CPP renderer builds (prerelease branch on steam) working, it kept crashing with errors like this:

```
[Message: Preloader] BepInEx 6.0.0-be.755 - Renderite.Renderer (28/4/2026 6:19:56 PM)
[Message: Preloader] Built from commit 3fab71a1914132a1ce3a545caf3192da603f2258
[Info   :   BepInEx] System platform: Windows 10 64-bit
[Info   :   BepInEx] Process bitness: 64-bit (x64)
[Info   :   BepInEx] Running under Unity 2019.4.19f1
[Info   :   BepInEx] Runtime version: 6.0.7
[Info   :   BepInEx] Runtime information: .NET 6.0.7
[Info   : Preloader] 0 patcher plugins loaded
[Info   : Preloader] 0 assemblies discovered
[Message:AssemblyPatcher] Executing 0 patch(es)
[Message:   BepInEx] Chainloader initialized
[Fatal  :   BepInEx] Unable to execute IL2CPP chainloader
[Error  :   BepInEx] System.InvalidOperationException: Sequence contains no elements
   at System.Linq.ThrowHelper.ThrowNoElementsException()
   at Il2CppInterop.Runtime.Injection.Hooks.MetadataCache_GetTypeInfoFromTypeDefinitionIndex_Hook.FindGetTypeInfoFromTypeDefinitionIndex(Boolean forceICallMethod) in /home/runner/work/Il2CppInterop/Il2CppInterop/Il2CppInterop.Runtime/Injection/Hooks/MetadataCache_GetTypeInfoFromTypeDefinitionIndex_Hook.cs:line 31
   at Il2CppInterop.Runtime.Injection.Hooks.MetadataCache_GetTypeInfoFromTypeDefinitionIndex_Hook.FindGetTypeInfoFromTypeDefinitionIndex(Boolean forceICallMethod) in /home/runner/work/Il2CppInterop/Il2CppInterop/Il2CppInterop.Runtime/Injection/Hooks/MetadataCache_GetTypeInfoFromTypeDefinitionIndex_Hook.cs:line 79
   at Il2CppInterop.Runtime.Injection.Hooks.MetadataCache_GetTypeInfoFromTypeDefinitionIndex_Hook.FindTargetMethod() in /home/runner/work/Il2CppInterop/Il2CppInterop/Il2CppInterop.Runtime/Injection/Hooks/MetadataCache_GetTypeInfoFromTypeDefinitionIndex_Hook.cs:line 119
   at Il2CppInterop.Runtime.Injection.Hook`1.ApplyHook() in /home/runner/work/Il2CppInterop/Il2CppInterop/Il2CppInterop.Runtime/Injection/Hook.cs:line 30
   at Il2CppInterop.Runtime.Injection.InjectorHelpers.Setup() in /home/runner/work/Il2CppInterop/Il2CppInterop/Il2CppInterop.Runtime/Injection/InjectorHelpers.cs:line 78
   at Il2CppInterop.Runtime.Injection.ClassInjector.RegisterTypeInIl2Cpp(Type type, RegisterTypeOptions options) in /home/runner/work/Il2CppInterop/Il2CppInterop/Il2CppInterop.Runtime/Injection/ClassInjector.cs:line 196
   at Il2CppInterop.Runtime.DelegateSupport.ConvertDelegate[TIl2Cpp](Delegate delegate) in /home/runner/work/Il2CppInterop/Il2CppInterop/Il2CppInterop.Runtime/DelegateSupport.cs:line 244
   at UnityEngine.Application.LogCallback.op_Implicit(Action`3 )
   at BepInEx.Unity.IL2CPP.Logging.IL2CPPUnityLogSource..ctor() in /home/runner/work/BepInEx/BepInEx/Runtimes/Unity/BepInEx.Unity.IL2CPP/Logging/IL2CPPUnityLogSource.cs:line 11
   at BepInEx.Unity.IL2CPP.IL2CPPChainloader.OnInvokeMethod(IntPtr method, IntPtr obj, IntPtr parameters, IntPtr exc) in /home/runner/work/BepInEx/BepInEx/Runtimes/Unity/BepInEx.Unity.IL2CPP/IL2CPPChainloader.cs:line 88
[Fatal  :   BepInEx] Unable to execute IL2CPP chainloader
[Error  :   BepInEx] System.InvalidOperationException: Sequence contains no elements
   at System.Linq.ThrowHelper.ThrowNoElementsException()
   at Il2CppInterop.Runtime.Injection.Hooks.MetadataCache_GetTypeInfoFromTypeDefinitionIndex_Hook.FindGetTypeInfoFromTypeDefinitionIndex(Boolean forceICallMethod) in /home/runner/work/Il2CppInterop/Il2CppInterop/Il2CppInterop.Runtime/Injection/Hooks/MetadataCache_GetTypeInfoFromTypeDefinitionIndex_Hook.cs:line 31
   at Il2CppInterop.Runtime.Injection.Hooks.MetadataCache_GetTypeInfoFromTypeDefinitionIndex_Hook.FindGetTypeInfoFromTypeDefinitionIndex(Boolean forceICallMethod) in /home/runner/work/Il2CppInterop/Il2CppInterop/Il2CppInterop.Runtime/Injection/Hooks/MetadataCache_GetTypeInfoFromTypeDefinitionIndex_Hook.cs:line 79
   at Il2CppInterop.Runtime.Injection.Hooks.MetadataCache_GetTypeInfoFromTypeDefinitionIndex_Hook.FindTargetMethod() in /home/runner/work/Il2CppInterop/Il2CppInterop/Il2CppInterop.Runtime/Injection/Hooks/MetadataCache_GetTypeInfoFromTypeDefinitionIndex_Hook.cs:line 119
   at Il2CppInterop.Runtime.Injection.Hook`1.ApplyHook() in /home/runner/work/Il2CppInterop/Il2CppInterop/Il2CppInterop.Runtime/Injection/Hook.cs:line 30
   at Il2CppInterop.Runtime.Injection.InjectorHelpers.Setup() in /home/runner/work/Il2CppInterop/Il2CppInterop/Il2CppInterop.Runtime/Injection/InjectorHelpers.cs:line 78
   at Il2CppInterop.Runtime.Injection.ClassInjector.RegisterTypeInIl2Cpp(Type type, RegisterTypeOptions options) in /home/runner/work/Il2CppInterop/Il2CppInterop/Il2CppInterop.Runtime/Injection/ClassInjector.cs:line 196
   at Il2CppInterop.Runtime.DelegateSupport.ConvertDelegate[TIl2Cpp](Delegate delegate) in /home/runner/work/Il2CppInterop/Il2CppInterop/Il2CppInterop.Runtime/DelegateSupport.cs:line 244
   at UnityEngine.Application.LogCallback.op_Implicit(Action`3 )
   at BepInEx.Unity.IL2CPP.Logging.IL2CPPUnityLogSource..ctor() in /home/runner/work/BepInEx/BepInEx/Runtimes/Unity/BepInEx.Unity.IL2CPP/Logging/IL2CPPUnityLogSource.cs:line 11
   at BepInEx.Unity.IL2CPP.IL2CPPChainloader.OnInvokeMethod(IntPtr method, IntPtr obj, IntPtr parameters, IntPtr exc) in /home/runner/work/BepInEx/BepInEx/Runtimes/Unity/BepInEx.Unity.IL2CPP/IL2CPPChainloader.cs:line 106
```

I've looked around and it seems to be a commonly reported issue, that is supposedly been fixed? https://github.com/BepInEx/Il2CppInterop/issues/119 https://github.com/BepInEx/Il2CppInterop/issues/183 https://github.com/BepInEx/BepInEx/issues/820 https://github.com/BepInEx/BepInEx/issues/1109

After investigating it it seems like: 
1. BepInEx couldn't find a function it was looking for because the compiler had inlined it.
Fix: if it looks inlined, just use the parent function instead.
2. A byte pattern scan got a false positive and returned a completely garbage memory address, crashing the runtime when it tried to use it.
Fix: make the bounds check more stricter, so that the address actually lives inside the DLL before trusting it.

I've not tested this with other games, if there is a small list of games (ideally free or smth) I can test against to make sure it works everywhere and it doesn't break already working stuff, I can do that. 