### PR TITLE
Fix duplicate types in generated assemblies on Unity 6.4+

### DIFF
--- a/Il2CppInterop.Generator/Passes/Pass79UnstripTypes.cs
+++ b/Il2CppInterop.Generator/Passes/Pass79UnstripTypes.cs
@@ -1,3 +1,4 @@
+using AsmResolver;
 using AsmResolver.DotNet;
 using AsmResolver.DotNet.Signatures;
 using AsmResolver.PE.DotNet.Metadata.Tables;
@@ -52,7 +53,7 @@ public static class Pass79UnstripTypes
 
         // If the parent type does not exist in the rewritten assembly, this nested type cannot be emitted safely.
         // Promoting it to a top-level type creates orphan compiler-generated types such as __O/__c.
-        if (unityType.DeclaringType != null && enclosingNewType == null && processedType == null)
+        if ((unityType.DeclaringType is null) != (enclosingNewType is null))
             return;
 
         if (unityType.IsEnum)
@@ -106,7 +107,7 @@ public static class Pass79UnstripTypes
             ProcessType(processedAssembly, nestedUnityType, processedType, imports, ref typesUnstripped);
     }
 
-    private static TypeDefinition CloneEnum(TypeDefinition sourceEnum, string convertedTypeName, RuntimeAssemblyReferences imports)
+    private static TypeDefinition CloneEnum(TypeDefinition sourceEnum, Utf8String convertedTypeName, RuntimeAssemblyReferences imports)
     {
         var newType = new TypeDefinition(sourceEnum.Namespace, convertedTypeName, ForcePublic(sourceEnum.Attributes),
             imports.Module.Enum().ToTypeDefOrRef());
@@ -147,10 +148,10 @@ public static class Pass79UnstripTypes
         return false;
     }
 
-    private static string GetConvertedUnityTypeName(RewriteGlobalContext context, TypeDefinition unityType)
+    private static Utf8String GetConvertedUnityTypeName(RewriteGlobalContext context, TypeDefinition unityType)
     {
         if (context.Options.PassthroughNames)
-            return unityType.Name;
+            return unityType.Name ?? Utf8String.Empty;
 
         return unityType.Name.MakeValidInSource();
     }

--- a/Il2CppInterop.Generator/Passes/Pass79UnstripTypes.cs
+++ b/Il2CppInterop.Generator/Passes/Pass79UnstripTypes.cs
@@ -47,15 +47,20 @@ public static class Pass79UnstripTypes
         if (unityType.BaseType != null && unityType.BaseType.FullName == "System.MulticastDelegate")
             return;
         var newModule = processedAssembly.NewAssembly.ManifestModule!;
-        var processedType = enclosingNewType == null
-            ? processedAssembly.TryGetTypeByName(unityType.FullName)?.NewType
-            : enclosingNewType.NestedTypes.SingleOrDefault(it => it.Name == unityType.Name);
+        var processedType = processedAssembly.TryGetTypeByName(unityType.FullName)?.NewType;
+        var convertedTypeName = GetConvertedUnityTypeName(processedAssembly.GlobalContext, unityType);
+
+        // If the parent type does not exist in the rewritten assembly, this nested type cannot be emitted safely.
+        // Promoting it to a top-level type creates orphan compiler-generated types such as __O/__c.
+        if (unityType.DeclaringType != null && enclosingNewType == null && processedType == null)
+            return;
+
         if (unityType.IsEnum)
         {
             if (processedType != null) return;
 
             typesUnstripped++;
-            var clonedType = CloneEnum(unityType, imports);
+            var clonedType = CloneEnum(unityType, convertedTypeName, imports);
             if (enclosingNewType == null)
             {
                 newModule.TopLevelTypes.Add(clonedType);
@@ -74,7 +79,8 @@ public static class Pass79UnstripTypes
             !unityType.HasGenericParameters()) // restore all types even if it would be not entirely correct
         {
             typesUnstripped++;
-            var clonedType = new TypeDefinition(unityType.Namespace, unityType.Name, ForcePublic(unityType.Attributes), unityType.BaseType == null ? null : newModule.DefaultImporter.ImportType(unityType.BaseType));
+            var clonedType = new TypeDefinition(unityType.Namespace, convertedTypeName, ForcePublic(unityType.Attributes),
+                unityType.BaseType == null ? null : newModule.DefaultImporter.ImportType(unityType.BaseType));
             if (enclosingNewType == null)
             {
                 newModule.TopLevelTypes.Add(clonedType);
@@ -100,9 +106,9 @@ public static class Pass79UnstripTypes
             ProcessType(processedAssembly, nestedUnityType, processedType, imports, ref typesUnstripped);
     }
 
-    private static TypeDefinition CloneEnum(TypeDefinition sourceEnum, RuntimeAssemblyReferences imports)
+    private static TypeDefinition CloneEnum(TypeDefinition sourceEnum, string convertedTypeName, RuntimeAssemblyReferences imports)
     {
-        var newType = new TypeDefinition(sourceEnum.Namespace, sourceEnum.Name, ForcePublic(sourceEnum.Attributes),
+        var newType = new TypeDefinition(sourceEnum.Namespace, convertedTypeName, ForcePublic(sourceEnum.Attributes),
             imports.Module.Enum().ToTypeDefOrRef());
         foreach (var sourceEnumField in sourceEnum.Fields)
         {
@@ -130,12 +136,23 @@ public static class Pass79UnstripTypes
             if (!fieldDefinition.Signature!.FieldType.IsValueType())
                 return true;
 
-            if (fieldDefinition.Signature.FieldType.Namespace?.StartsWith("System") ?? false &&
-                HasNonBlittableFields(fieldDefinition.Signature.FieldType.Resolve()))
-                return true;
+            if (fieldDefinition.Signature.FieldType.Namespace?.StartsWith("System") ?? false)
+            {
+                var resolved = fieldDefinition.Signature.FieldType.Resolve();
+                if (resolved != null && HasNonBlittableFields(resolved))
+                    return true;
+            }
         }
 
         return false;
+    }
+
+    private static string GetConvertedUnityTypeName(RewriteGlobalContext context, TypeDefinition unityType)
+    {
+        if (context.Options.PassthroughNames)
+            return unityType.Name;
+
+        return unityType.Name.MakeValidInSource();
     }
 
     private static TypeAttributes ForcePublic(TypeAttributes typeAttributes)


### PR DESCRIPTION


The game crashed on version 6000.4.7. The content of ErrorLog.log is as follows
```
Unhandled exception. System.IO.FileNotFoundException:
Could not load file or assembly 'UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'
```

## Cause 

The real error was BadImageFormatException: Duplicate type with name '__O' — the FileNotFoundException was just the surface. Pass79UnstripTypes was producing a UnityEngine.CoreModule.dll with duplicate types, which CoreCLR refused to load. Three bugs in the pass caused this:

1. Types like <>O were named <>O in one path and __O in another, creating duplicates of the same logical type.
2. Nested types were looked up by simple name only, so types already in the output were missed and re-created.
3. Nested types whose parent was never emitted were incorrectly promoted to top-level, producing multiple top-level __O and __c.

## Fix

- Use unified type name conversion (MakeValidInSource) for all unstripped types
- Look up types by FullName consistently instead of simple name
- Skip nested types when parent type is not in the output assembly
- Add null guard for Resolve() in HasNonBlittableFields recursion