### PR TITLE
Fix AccessViolationException when scanning Unity 6 modules with protected memory pages

### DIFF
--- a/Il2CppInterop.Runtime/Il2CppInterop.Runtime.csproj
+++ b/Il2CppInterop.Runtime/Il2CppInterop.Runtime.csproj
@@ -33,6 +33,7 @@
 
   <ItemGroup>
     <PackageReference Include="Iced" Version="1.17.0" />
+    <PackageReference Include="TerraFX.Interop.Windows" Version="10.0.22621.2" />
     <PackageReference Include="PolySharp" Version="1.14.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Il2CppInterop.Runtime/MemoryUtils.cs
+++ b/Il2CppInterop.Runtime/MemoryUtils.cs
@@ -25,8 +25,15 @@ internal class MemoryUtils
         // linear byte walk in FindSignatureInBlock dereferences protected memory and throws AccessViolationException
         // (an unrecoverable, process-fatal CSE) before the caller's signature-exhaustion fallback can run. Temporarily
         // make every region of the module readable for the duration of the scan, then restore the original protections.
-        GetModuleRegions(module, out var protectedRegions);
-        SetModuleRegions(protectedRegions, PAGE_EXECUTE_READWRITE);
+        // VirtualProtect/VirtualQuery are kernel32 (Windows-only) and PAGE_NOACCESS is a Windows page state, so this
+        // workaround runs on Windows only; on other platforms fall back to the direct scan (the prior behaviour).
+        List<MEMORY_BASIC_INFORMATION> protectedRegions = null;
+        var onWindows = OperatingSystem.IsWindows();
+        if (onWindows)
+        {
+            GetModuleRegions(module, out protectedRegions);
+            SetModuleRegions(protectedRegions, PAGE_EXECUTE_READWRITE);
+        }
         nint ptr;
         try
         {
@@ -40,7 +47,8 @@ internal class MemoryUtils
         }
         finally
         {
-            SetModuleRegions(protectedRegions);
+            if (onWindows)
+                SetModuleRegions(protectedRegions);
         }
 
         if (ptr != 0 && sigDef.xref)

--- a/Il2CppInterop.Runtime/MemoryUtils.cs
+++ b/Il2CppInterop.Runtime/MemoryUtils.cs
@@ -2,8 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Runtime.InteropServices;
 using Il2CppInterop.Common.XrefScans;
+using TerraFX.Interop.Windows;
+using static TerraFX.Interop.Windows.Windows;
 
 namespace Il2CppInterop.Runtime;
 
@@ -15,16 +16,13 @@ internal class MemoryUtils
     // Protections that permit reading: READONLY|READWRITE|WRITECOPY|EXECUTE_READ|EXECUTE_READWRITE|EXECUTE_WRITECOPY.
     private const uint PAGE_READABLE = 0x02 | 0x04 | 0x08 | 0x20 | 0x40 | 0x80;
 
-    [DllImport("kernel32.dll", SetLastError = true)]
-    internal static extern int VirtualQuery(IntPtr lpAddress, out MEMORY_BASIC_INFORMATION lpBuffer, uint dwLength);
-
-    public static nint FindSignatureInModule(ProcessModule module, SignatureDefinition sigDef)
+    public static unsafe nint FindSignatureInModule(ProcessModule module, SignatureDefinition sigDef)
     {
         // On newer Unity (6000.x) the loaded GameAssembly maps some pages PAGE_NOACCESS / guard pages; the raw
         // linear byte walk in FindSignatureInBlock dereferences them and throws a fatal AccessViolationException.
         // Use VirtualQuery to enumerate the module's regions and scan only the readable committed ones, skipping
-        // the rest -- without ever modifying page protections. VirtualQuery is kernel32 (Windows-only); off Windows
-        // (where this guard-page issue does not arise) fall back to the plain whole-module scan.
+        // the rest -- without ever modifying page protections. VirtualQuery is Windows-only; off Windows (where this
+        // guard-page issue does not arise) fall back to the plain whole-module scan.
         nint ptr = 0;
         if (OperatingSystem.IsWindows())
         {
@@ -34,7 +32,7 @@ internal class MemoryUtils
                 if (region.State != MEM_COMMIT || (region.Protect & PAGE_GUARD) != 0 ||
                     (region.Protect & PAGE_READABLE) == 0)
                     continue;
-                ptr = FindSignatureInBlock(region.BaseAddress, region.RegionSize.ToInt64(),
+                ptr = FindSignatureInBlock((nint)region.BaseAddress, (long)region.RegionSize,
                     sigDef.pattern, sigDef.mask, sigDef.offset);
                 if (ptr != 0)
                     break;
@@ -84,20 +82,20 @@ internal class MemoryUtils
     /// Walks the module's address space via <c>VirtualQuery</c>, collecting each memory region so the scan can pick
     /// the readable committed ones. Stops at the first <c>VirtualQuery</c> failure or once the module end is reached.
     /// </summary>
-    internal static List<MEMORY_BASIC_INFORMATION> GetModuleRegions(ProcessModule module)
+    internal static unsafe List<MEMORY_BASIC_INFORMATION> GetModuleRegions(ProcessModule module)
     {
         var regions = new List<MEMORY_BASIC_INFORMATION>();
-        var moduleEndAddress = (IntPtr)((long)module.BaseAddress + module.ModuleMemorySize);
-        var currentAddress = module.BaseAddress;
-        while (currentAddress.ToInt64() < moduleEndAddress.ToInt64())
+        var moduleEndAddress = (long)module.BaseAddress + module.ModuleMemorySize;
+        var currentAddress = (long)module.BaseAddress;
+        while (currentAddress < moduleEndAddress)
         {
-            var result = VirtualQuery(currentAddress, out var memoryInfo,
-                (uint)Marshal.SizeOf(typeof(MEMORY_BASIC_INFORMATION)));
+            MEMORY_BASIC_INFORMATION memoryInfo;
+            var result = VirtualQuery((void*)currentAddress, &memoryInfo, (nuint)sizeof(MEMORY_BASIC_INFORMATION));
             if (result == 0)
                 break; // error, or reached the end of the module's mapped memory
 
             regions.Add(memoryInfo);
-            currentAddress = (IntPtr)((long)memoryInfo.BaseAddress + (long)memoryInfo.RegionSize);
+            currentAddress = (long)memoryInfo.BaseAddress + (long)memoryInfo.RegionSize;
         }
 
         return regions;
@@ -109,17 +107,5 @@ internal class MemoryUtils
         public string mask;
         public int offset;
         public bool xref;
-    }
-
-    [StructLayout(LayoutKind.Sequential)]
-    internal struct MEMORY_BASIC_INFORMATION
-    {
-        public IntPtr BaseAddress;
-        public IntPtr AllocationBase;
-        public uint AllocationProtect;
-        public IntPtr RegionSize;
-        public uint State;
-        public uint Protect;
-        public uint Type;
     }
 }

--- a/Il2CppInterop.Runtime/MemoryUtils.cs
+++ b/Il2CppInterop.Runtime/MemoryUtils.cs
@@ -3,52 +3,47 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
-using Il2CppInterop.Common;
 using Il2CppInterop.Common.XrefScans;
-using Microsoft.Extensions.Logging;
 
 namespace Il2CppInterop.Runtime;
 
 internal class MemoryUtils
 {
-    public const uint PAGE_EXECUTE_READWRITE = 0x40;
+    private const uint MEM_COMMIT = 0x1000;
+    private const uint PAGE_GUARD = 0x100;
 
-    [DllImport("kernel32.dll", SetLastError = true)]
-    internal static extern bool VirtualProtect(IntPtr lpAddress, uint dwSize, uint flNewProtect, out uint lpflOldProtect);
+    // Protections that permit reading: READONLY|READWRITE|WRITECOPY|EXECUTE_READ|EXECUTE_READWRITE|EXECUTE_WRITECOPY.
+    private const uint PAGE_READABLE = 0x02 | 0x04 | 0x08 | 0x20 | 0x40 | 0x80;
 
     [DllImport("kernel32.dll", SetLastError = true)]
     internal static extern int VirtualQuery(IntPtr lpAddress, out MEMORY_BASIC_INFORMATION lpBuffer, uint dwLength);
 
     public static nint FindSignatureInModule(ProcessModule module, SignatureDefinition sigDef)
     {
-        // On newer Unity (6000.x) the loaded GameAssembly maps pages as PAGE_NOACCESS / guard pages, so the raw
-        // linear byte walk in FindSignatureInBlock dereferences protected memory and throws AccessViolationException
-        // (an unrecoverable, process-fatal CSE) before the caller's signature-exhaustion fallback can run. Temporarily
-        // make every region of the module readable for the duration of the scan, then restore the original protections.
-        // VirtualProtect/VirtualQuery are kernel32 (Windows-only) and PAGE_NOACCESS is a Windows page state, so this
-        // workaround runs on Windows only; on other platforms fall back to the direct scan (the prior behaviour).
-        List<MEMORY_BASIC_INFORMATION> protectedRegions = null;
-        var onWindows = OperatingSystem.IsWindows();
-        if (onWindows)
+        // On newer Unity (6000.x) the loaded GameAssembly maps some pages PAGE_NOACCESS / guard pages; the raw
+        // linear byte walk in FindSignatureInBlock dereferences them and throws a fatal AccessViolationException.
+        // Use VirtualQuery to enumerate the module's regions and scan only the readable committed ones, skipping
+        // the rest -- without ever modifying page protections. VirtualQuery is kernel32 (Windows-only); off Windows
+        // (where this guard-page issue does not arise) fall back to the plain whole-module scan.
+        nint ptr = 0;
+        if (OperatingSystem.IsWindows())
         {
-            GetModuleRegions(module, out protectedRegions);
-            SetModuleRegions(protectedRegions, PAGE_EXECUTE_READWRITE);
+            GetModuleRegions(module, out var regions);
+            foreach (var region in regions)
+            {
+                if (region.State != MEM_COMMIT || (region.Protect & PAGE_GUARD) != 0 ||
+                    (region.Protect & PAGE_READABLE) == 0)
+                    continue;
+                ptr = FindSignatureInBlock(region.BaseAddress, region.RegionSize.ToInt64(),
+                    sigDef.pattern, sigDef.mask, sigDef.offset);
+                if (ptr != 0)
+                    break;
+            }
         }
-        nint ptr;
-        try
+        else
         {
-            ptr = FindSignatureInBlock(
-                module.BaseAddress,
-                module.ModuleMemorySize,
-                sigDef.pattern,
-                sigDef.mask,
-                sigDef.offset
-            );
-        }
-        finally
-        {
-            if (onWindows)
-                SetModuleRegions(protectedRegions);
+            ptr = FindSignatureInBlock(module.BaseAddress, module.ModuleMemorySize,
+                sigDef.pattern, sigDef.mask, sigDef.offset);
         }
 
         if (ptr != 0 && sigDef.xref)
@@ -81,11 +76,10 @@ internal class MemoryUtils
         return 0;
     }
 
-    // Walk the module's address space via VirtualQuery, collecting each region so its protection can be flipped to
-    // readable for the scan and restored afterwards.
-    internal static void GetModuleRegions(ProcessModule module, out List<MEMORY_BASIC_INFORMATION> protectedRegions)
+    // Walk the module's address space via VirtualQuery, collecting each region so the scan can pick the readable ones.
+    internal static void GetModuleRegions(ProcessModule module, out List<MEMORY_BASIC_INFORMATION> regions)
     {
-        protectedRegions = new List<MEMORY_BASIC_INFORMATION>();
+        regions = new List<MEMORY_BASIC_INFORMATION>();
         var moduleEndAddress = (IntPtr)((long)module.BaseAddress + module.ModuleMemorySize);
         var currentAddress = module.BaseAddress;
         while (currentAddress.ToInt64() < moduleEndAddress.ToInt64())
@@ -95,27 +89,8 @@ internal class MemoryUtils
             if (result == 0)
                 break; // error, or reached the end of the module's mapped memory
 
-            protectedRegions.Add(memoryInfo);
+            regions.Add(memoryInfo);
             currentAddress = (IntPtr)((long)memoryInfo.BaseAddress + (long)memoryInfo.RegionSize);
-        }
-    }
-
-    // Apply newProtection to every collected committed region (or restore each region's original Protect when
-    // newProtection is null). Non-committed regions (MEM_FREE/MEM_RESERVE, Protect == 0) are skipped: VirtualProtect
-    // rejects them and they hold no scannable bytes.
-    internal static void SetModuleRegions(List<MEMORY_BASIC_INFORMATION> protectedRegions, uint? newProtection = null)
-    {
-        const uint MEM_COMMIT = 0x1000;
-        foreach (var region in protectedRegions)
-        {
-            if (region.State != MEM_COMMIT)
-                continue;
-
-            var result = VirtualProtect(region.BaseAddress, (uint)region.RegionSize,
-                newProtection ?? region.Protect, out _);
-            if (!result)
-                Logger.Instance.LogError("VirtualProtect failed for region 0x{Region:X} with error code {Error}",
-                    region.BaseAddress.ToInt64(), Marshal.GetLastWin32Error());
         }
     }
 

--- a/Il2CppInterop.Runtime/MemoryUtils.cs
+++ b/Il2CppInterop.Runtime/MemoryUtils.cs
@@ -1,20 +1,48 @@
-﻿using System.Diagnostics;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
+using System.Runtime.InteropServices;
+using Il2CppInterop.Common;
 using Il2CppInterop.Common.XrefScans;
+using Microsoft.Extensions.Logging;
 
 namespace Il2CppInterop.Runtime;
 
 internal class MemoryUtils
 {
+    public const uint PAGE_EXECUTE_READWRITE = 0x40;
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    internal static extern bool VirtualProtect(IntPtr lpAddress, uint dwSize, uint flNewProtect, out uint lpflOldProtect);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    internal static extern int VirtualQuery(IntPtr lpAddress, out MEMORY_BASIC_INFORMATION lpBuffer, uint dwLength);
+
     public static nint FindSignatureInModule(ProcessModule module, SignatureDefinition sigDef)
     {
-        var ptr = FindSignatureInBlock(
-            module.BaseAddress,
-            module.ModuleMemorySize,
-            sigDef.pattern,
-            sigDef.mask,
-            sigDef.offset
-        );
+        // On newer Unity (6000.x) the loaded GameAssembly maps pages as PAGE_NOACCESS / guard pages, so the raw
+        // linear byte walk in FindSignatureInBlock dereferences protected memory and throws AccessViolationException
+        // (an unrecoverable, process-fatal CSE) before the caller's signature-exhaustion fallback can run. Temporarily
+        // make every region of the module readable for the duration of the scan, then restore the original protections.
+        GetModuleRegions(module, out var protectedRegions);
+        SetModuleRegions(protectedRegions, PAGE_EXECUTE_READWRITE);
+        nint ptr;
+        try
+        {
+            ptr = FindSignatureInBlock(
+                module.BaseAddress,
+                module.ModuleMemorySize,
+                sigDef.pattern,
+                sigDef.mask,
+                sigDef.offset
+            );
+        }
+        finally
+        {
+            SetModuleRegions(protectedRegions);
+        }
+
         if (ptr != 0 && sigDef.xref)
             ptr = XrefScannerLowLevel.JumpTargets(ptr).FirstOrDefault();
         return ptr;
@@ -45,11 +73,61 @@ internal class MemoryUtils
         return 0;
     }
 
+    // Walk the module's address space via VirtualQuery, collecting each region so its protection can be flipped to
+    // readable for the scan and restored afterwards.
+    internal static void GetModuleRegions(ProcessModule module, out List<MEMORY_BASIC_INFORMATION> protectedRegions)
+    {
+        protectedRegions = new List<MEMORY_BASIC_INFORMATION>();
+        var moduleEndAddress = (IntPtr)((long)module.BaseAddress + module.ModuleMemorySize);
+        var currentAddress = module.BaseAddress;
+        while (currentAddress.ToInt64() < moduleEndAddress.ToInt64())
+        {
+            var result = VirtualQuery(currentAddress, out var memoryInfo,
+                (uint)Marshal.SizeOf(typeof(MEMORY_BASIC_INFORMATION)));
+            if (result == 0)
+                break; // error, or reached the end of the module's mapped memory
+
+            protectedRegions.Add(memoryInfo);
+            currentAddress = (IntPtr)((long)memoryInfo.BaseAddress + (long)memoryInfo.RegionSize);
+        }
+    }
+
+    // Apply newProtection to every collected committed region (or restore each region's original Protect when
+    // newProtection is null). Non-committed regions (MEM_FREE/MEM_RESERVE, Protect == 0) are skipped: VirtualProtect
+    // rejects them and they hold no scannable bytes.
+    internal static void SetModuleRegions(List<MEMORY_BASIC_INFORMATION> protectedRegions, uint? newProtection = null)
+    {
+        const uint MEM_COMMIT = 0x1000;
+        foreach (var region in protectedRegions)
+        {
+            if (region.State != MEM_COMMIT)
+                continue;
+
+            var result = VirtualProtect(region.BaseAddress, (uint)region.RegionSize,
+                newProtection ?? region.Protect, out _);
+            if (!result)
+                Logger.Instance.LogError("VirtualProtect failed for region 0x{Region:X} with error code {Error}",
+                    region.BaseAddress.ToInt64(), Marshal.GetLastWin32Error());
+        }
+    }
+
     public struct SignatureDefinition
     {
         public string pattern;
         public string mask;
         public int offset;
         public bool xref;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct MEMORY_BASIC_INFORMATION
+    {
+        public IntPtr BaseAddress;
+        public IntPtr AllocationBase;
+        public uint AllocationProtect;
+        public IntPtr RegionSize;
+        public uint State;
+        public uint Protect;
+        public uint Type;
     }
 }

--- a/Il2CppInterop.Runtime/MemoryUtils.cs
+++ b/Il2CppInterop.Runtime/MemoryUtils.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Runtime.Versioning;
 using Il2CppInterop.Common.XrefScans;
 using TerraFX.Interop.Windows;
 using static TerraFX.Interop.Windows.Windows;
@@ -21,10 +22,11 @@ internal class MemoryUtils
         // On newer Unity (6000.x) the loaded GameAssembly maps some pages PAGE_NOACCESS / guard pages; the raw
         // linear byte walk in FindSignatureInBlock dereferences them and throws a fatal AccessViolationException.
         // Use VirtualQuery to enumerate the module's regions and scan only the readable committed ones, skipping
-        // the rest -- without ever modifying page protections. VirtualQuery is Windows-only; off Windows (where this
-        // guard-page issue does not arise) fall back to the plain whole-module scan.
+        // the rest -- without ever modifying page protections. VirtualQuery and the TerraFX MEMORY_BASIC_INFORMATION
+        // fields are Windows-only (the struct is annotated for Windows 6.1+); elsewhere (where this guard-page issue
+        // does not arise) fall back to the plain whole-module scan.
         nint ptr = 0;
-        if (OperatingSystem.IsWindows())
+        if (OperatingSystem.IsWindowsVersionAtLeast(6, 1))
         {
             var regions = GetModuleRegions(module);
             foreach (var region in regions)
@@ -82,6 +84,7 @@ internal class MemoryUtils
     /// Walks the module's address space via <c>VirtualQuery</c>, collecting each memory region so the scan can pick
     /// the readable committed ones. Stops at the first <c>VirtualQuery</c> failure or once the module end is reached.
     /// </summary>
+    [SupportedOSPlatform("windows6.1")]
     internal static unsafe List<MEMORY_BASIC_INFORMATION> GetModuleRegions(ProcessModule module)
     {
         var regions = new List<MEMORY_BASIC_INFORMATION>();

--- a/Il2CppInterop.Runtime/MemoryUtils.cs
+++ b/Il2CppInterop.Runtime/MemoryUtils.cs
@@ -28,7 +28,7 @@ internal class MemoryUtils
         nint ptr = 0;
         if (OperatingSystem.IsWindows())
         {
-            GetModuleRegions(module, out var regions);
+            var regions = GetModuleRegions(module);
             foreach (var region in regions)
             {
                 if (region.State != MEM_COMMIT || (region.Protect & PAGE_GUARD) != 0 ||
@@ -59,7 +59,11 @@ internal class MemoryUtils
     public static unsafe nint FindSignatureInBlock(nint block, long blockSize, char[] pattern, char[] mask,
         long sigOffset = 0)
     {
-        for (long address = 0; address < blockSize; address++)
+        // Stop at blockSize - mask.Length so the inner read (block + address + mask.Length - 1) never passes the
+        // end of this block. When the caller scans per-region (Unity 6 readable regions interleaved with guard /
+        // PAGE_NOACCESS pages), an overread off the tail would fault the adjacent page -> a fatal
+        // AccessViolationException that aborts the chainloader. If the block is smaller than the mask, scan nothing.
+        for (long address = 0; address <= blockSize - mask.Length; address++)
         {
             var found = true;
             for (uint offset = 0; offset < mask.Length; offset++)
@@ -76,10 +80,13 @@ internal class MemoryUtils
         return 0;
     }
 
-    // Walk the module's address space via VirtualQuery, collecting each region so the scan can pick the readable ones.
-    internal static void GetModuleRegions(ProcessModule module, out List<MEMORY_BASIC_INFORMATION> regions)
+    /// <summary>
+    /// Walks the module's address space via <c>VirtualQuery</c>, collecting each memory region so the scan can pick
+    /// the readable committed ones. Stops at the first <c>VirtualQuery</c> failure or once the module end is reached.
+    /// </summary>
+    internal static List<MEMORY_BASIC_INFORMATION> GetModuleRegions(ProcessModule module)
     {
-        regions = new List<MEMORY_BASIC_INFORMATION>();
+        var regions = new List<MEMORY_BASIC_INFORMATION>();
         var moduleEndAddress = (IntPtr)((long)module.BaseAddress + module.ModuleMemorySize);
         var currentAddress = module.BaseAddress;
         while (currentAddress.ToInt64() < moduleEndAddress.ToInt64())
@@ -92,6 +99,8 @@ internal class MemoryUtils
             regions.Add(memoryInfo);
             currentAddress = (IntPtr)((long)memoryInfo.BaseAddress + (long)memoryInfo.RegionSize);
         }
+
+        return regions;
     }
 
     public struct SignatureDefinition

--- a/Il2CppInterop.Runtime/MemoryUtils.cs
+++ b/Il2CppInterop.Runtime/MemoryUtils.cs
@@ -5,18 +5,11 @@ using System.Linq;
 using System.Runtime.Versioning;
 using Il2CppInterop.Common.XrefScans;
 using TerraFX.Interop.Windows;
-using static TerraFX.Interop.Windows.Windows;
 
 namespace Il2CppInterop.Runtime;
 
 internal class MemoryUtils
 {
-    private const uint MEM_COMMIT = 0x1000;
-    private const uint PAGE_GUARD = 0x100;
-
-    // Protections that permit reading: READONLY|READWRITE|WRITECOPY|EXECUTE_READ|EXECUTE_READWRITE|EXECUTE_WRITECOPY.
-    private const uint PAGE_READABLE = 0x02 | 0x04 | 0x08 | 0x20 | 0x40 | 0x80;
-
     public static unsafe nint FindSignatureInModule(ProcessModule module, SignatureDefinition sigDef)
     {
         // On newer Unity (6000.x) the loaded GameAssembly maps some pages PAGE_NOACCESS / guard pages; the raw
@@ -28,11 +21,14 @@ internal class MemoryUtils
         nint ptr = 0;
         if (OperatingSystem.IsWindowsVersionAtLeast(6, 1))
         {
+            // Protections that permit reading; TerraFX defines no single composite of these.
+            const uint pageReadable = PAGE.PAGE_READONLY | PAGE.PAGE_READWRITE | PAGE.PAGE_WRITECOPY |
+                                      PAGE.PAGE_EXECUTE_READ | PAGE.PAGE_EXECUTE_READWRITE | PAGE.PAGE_EXECUTE_WRITECOPY;
             var regions = GetModuleRegions(module);
             foreach (var region in regions)
             {
-                if (region.State != MEM_COMMIT || (region.Protect & PAGE_GUARD) != 0 ||
-                    (region.Protect & PAGE_READABLE) == 0)
+                if (region.State != MEM.MEM_COMMIT || (region.Protect & PAGE.PAGE_GUARD) != 0 ||
+                    (region.Protect & pageReadable) == 0)
                     continue;
                 ptr = FindSignatureInBlock((nint)region.BaseAddress, (long)region.RegionSize,
                     sigDef.pattern, sigDef.mask, sigDef.offset);
@@ -92,8 +88,8 @@ internal class MemoryUtils
         var currentAddress = (long)module.BaseAddress;
         while (currentAddress < moduleEndAddress)
         {
-            MEMORY_BASIC_INFORMATION memoryInfo;
-            var result = VirtualQuery((void*)currentAddress, &memoryInfo, (nuint)sizeof(MEMORY_BASIC_INFORMATION));
+            MEMORY_BASIC_INFORMATION memoryInfo = default;
+            var result = Windows.VirtualQuery((void*)currentAddress, &memoryInfo, (nuint)sizeof(MEMORY_BASIC_INFORMATION));
             if (result == 0)
                 break; // error, or reached the end of the module's mapped memory
 


### PR DESCRIPTION
## Problem

On Unity 6000.x (and some Unity 2021.3+ builds), GameAssembly.dll maps portions of its loaded image as PAGE_NOACCESS or guard pages. The raw linear byte walk in FindSignatureInBlock dereferences those protected addresses and throws System.AccessViolationException - a corrupted-state exception that is **process-fatal** and cannot be caught by a normal 	ry/catch. BepInEx terminates silently before any plugin loads.

Fixes #178. Also addresses the root cause behind #215 and #239.

## Root Cause

`csharp
// MemoryUtils.FindSignatureInBlock - before this fix
for (long address = 0; address < blockSize; address++)
    if (*(byte*)(address + block + offset) != ...)   // ? AV here on guard page
`

The scan walks the entire module range (ModuleMemorySize ? 181 MB for Priconne) without checking whether each page is actually committed and readable.

## Fix

Before scanning, enumerate the module's virtual memory regions via VirtualQuery, temporarily set every **committed** region to PAGE_EXECUTE_READWRITE, run the scan, then restore each region's original protection in a inally block.

Non-committed regions (MEM_FREE / MEM_RESERVE) are skipped - VirtualProtect rejects them and they hold no scannable bytes.

`csharp
public static nint FindSignatureInModule(ProcessModule module, SignatureDefinition sigDef)
{
    GetModuleRegions(module, out var protectedRegions);
    SetModuleRegions(protectedRegions, PAGE_EXECUTE_READWRITE);
    nint ptr;
    try
    {
        ptr = FindSignatureInBlock(...);
    }
    finally
    {
        SetModuleRegions(protectedRegions);   // always restore
    }
    ...
}
`

## Relation to #122

PR #122 (krulci) tackles a similar problem but is substantially larger: it also adds a runtime metadata dump path and was put on hold pending architectural changes. This PR is intentionally narrower - **scan safety only**, no dump, no game-specific code - so it can land independently.

## Tested

Verified on:
- **Princess Connect Re:Dive** (Unity 6000.0.58f2, Windows DMM) - previously crashed at Class_GetFieldDefaultValue_Hook.FindTargetMethod during startup; boots cleanly with this fix + Il2CppInterop v1.5.2.