### PR TITLE
Fix out-of-bounds scan read and a dead non-blittable-field check

### DIFF
--- a/Il2CppInterop.Generator/Passes/Pass16ScanMethodRefs.cs
+++ b/Il2CppInterop.Generator/Passes/Pass16ScanMethodRefs.cs
@@ -110,7 +110,9 @@ public static class Pass16ScanMethodRefs
     {
         var bytes = (byte*)basePtr;
         var sequence = Encoding.UTF8.GetBytes(str);
-        for (var i = 0L; i < length; i++)
+        // i + j must stay within [0, length): cap i so the inner read bytes[i + (sequence.Length - 1)]
+        // never passes the end of the mapped view (an out-of-bounds read = AccessViolation).
+        for (var i = 0L; i <= length - sequence.Length; i++)
         {
             for (var j = 0; j < sequence.Length; j++)
                 if (bytes[i + j] != sequence[j])

--- a/Il2CppInterop.Generator/Passes/Pass79UnstripTypes.cs
+++ b/Il2CppInterop.Generator/Passes/Pass79UnstripTypes.cs
@@ -130,7 +130,7 @@ public static class Pass79UnstripTypes
             if (!fieldDefinition.Signature!.FieldType.IsValueType())
                 return true;
 
-            if (fieldDefinition.Signature.FieldType.Namespace?.StartsWith("System") ?? false &&
+            if ((fieldDefinition.Signature.FieldType.Namespace?.StartsWith("System") ?? false) &&
                 HasNonBlittableFields(fieldDefinition.Signature.FieldType.Resolve()))
                 return true;
         }


### PR DESCRIPTION
Two independent correctness fixes in the IL2CPP generator passes, both verified by reading the code (build green).

## Pass16 `FindByteSequence` - out-of-bounds read

The outer loop runs `i` from `0` to `length - 1`, while the inner loop reads `bytes[i + j]` with `j` up to `sequence.Length - 1`. For the last `sequence.Length - 1` positions, `bytes[i + j]` reads past the end of the `MemoryMappedViewAccessor`-mapped region - an `AccessViolationException` that terminates the process (it cannot be caught by managed code). On a real game binary the final bytes of the mapped view are read out of bounds on every scan.

Fix: cap the outer bound to `i <= length - sequence.Length`, so the maximum index is `(length - sequence.Length) + (sequence.Length - 1) = length - 1`. When `length < sequence.Length` the (long) condition is immediately false, so the scan correctly returns no match.

## Pass79 `HasNonBlittableFields` - dead recursive check

`??` binds looser than `&&`, so

```csharp
fieldDefinition.Signature.FieldType.Namespace?.StartsWith("System") ?? false &&
    HasNonBlittableFields(fieldDefinition.Signature.FieldType.Resolve())
```

parses as `Namespace?.StartsWith("System") ?? (false && HasNonBlittableFields(...))`. The right side of `??` short-circuits to `false`, and when `Namespace` is non-null `??` never fires - so the recursive call is never made. System value types that contain non-blittable fields are therefore not detected as non-blittable. Parenthesising the null-coalescing sub-expression restores the intended `(... ?? false) && HasNonBlittableFields(...)`.