### PR TITLE
Throw specific exception types instead of Exception/ApplicationException

### DIFF
--- a/Il2CppInterop.Runtime/Injection/ClassInjector.cs
+++ b/Il2CppInterop.Runtime/Injection/ClassInjector.cs
@@ -452,7 +452,7 @@ public static unsafe partial class ClassInjector
 
             if (vTablePointer[i].method == default || vTablePointer[i].methodPtr == IntPtr.Zero)
             {
-                throw new Exception("No method found for vtable entry " + methodName);
+                throw new InvalidOperationException($"No concrete method implementation was found for vtable slot '{methodName}' while injecting type '{type.FullName}'.");
             }
         }
 
@@ -1147,7 +1147,7 @@ public static unsafe partial class ClassInjector
         var fullName = GetIl2CppTypeFullName(typePointer);
         var type = Type.GetType(fullName)
             ?? Type.GetType(fullName.Contains('.') ? "Il2Cpp" + fullName : "Il2Cpp." + fullName)
-            ?? throw new NullReferenceException($"Couldn't find System.Type for Il2Cpp type: {fullName}");
+            ?? throw new TypeLoadException($"Could not resolve the managed System.Type for IL2CPP type '{fullName}'. Ensure the corresponding interop assembly is loaded.");
 
         INativeTypeStruct wrappedType = UnityVersionHandler.Wrap(typePointer);
         if (wrappedType.Type == Il2CppTypeEnum.IL2CPP_TYPE_GENERICINST)

--- a/Il2CppInterop.Runtime/Injection/Hook.cs
+++ b/Il2CppInterop.Runtime/Injection/Hook.cs
@@ -20,7 +20,7 @@ namespace Il2CppInterop.Runtime.Injection
 
         public virtual void TargetMethodNotFound()
         {
-            throw new Exception($"Required target method {TargetMethodName} not found");
+            throw new NotSupportedException($"Required target method {TargetMethodName} was not found in the game binary. The current Unity/IL2CPP version may be unsupported.");
         }
 
         public void ApplyHook()

--- a/Il2CppInterop.Runtime/Injection/Hooks/Class_GetFieldDefaultValue_Hook.cs
+++ b/Il2CppInterop.Runtime/Injection/Hooks/Class_GetFieldDefaultValue_Hook.cs
@@ -88,7 +88,7 @@ namespace Il2CppInterop.Runtime.Injection.Hooks
                 // MonoField isn't present on 2021.2.0+
                 var monoFieldType = InjectorHelpers.Il2CppMscorlib.GetTypesSafe().SingleOrDefault((x) => x.Name is "MonoField");
                 if (monoFieldType == null)
-                    throw new Exception($"Unity {Il2CppInteropRuntime.Instance.UnityVersion} is not supported at the moment: MonoField isn't present in Il2Cppmscorlib.dll for unity version, unable to fetch icall");
+                    throw new NotSupportedException($"Unity {Il2CppInteropRuntime.Instance.UnityVersion} is not supported: MonoField is absent from Il2Cppmscorlib.dll, unable to fetch the icall");
 
                 var monoFieldGetValueInternalThunk = InjectorHelpers.GetIl2CppMethodPointer(monoFieldType.GetMethod(nameof(Il2CppSystem.Reflection.MonoField.GetValueInternal)));
                 Logger.Instance.LogTrace("Il2CppSystem.Reflection.MonoField::thunk_GetValueInternal: 0x{MonoFieldGetValueInternalThunkAddress}", monoFieldGetValueInternalThunk.ToInt64().ToString("X2"));

--- a/Il2CppInterop.Runtime/Runtime/UnityVersionHandler.cs
+++ b/Il2CppInterop.Runtime/Runtime/UnityVersionHandler.cs
@@ -121,7 +121,7 @@ public static class UnityVersionHandler
 
         Logger.Instance.LogError("No direct for {TypeFullName} found for Unity {UnityVersion}; this likely indicates a severe error somewhere", typeof(T).FullName, Il2CppInteropRuntime.Instance.UnityVersion);
 
-        throw new ApplicationException("No handler");
+        throw new InvalidOperationException($"No native struct handler for {typeof(T).FullName} was found for Unity {Il2CppInteropRuntime.Instance.UnityVersion}. This Unity version may be unsupported.");
     }
 
     private static Type[] GetAllTypesSafe()


### PR DESCRIPTION
Replace bare `System.Exception`, the deprecated `ApplicationException`, and a misused `NullReferenceException` sentinel with specific exception types, so callers can catch them meaningfully and crash reports/debuggers are not misled (CA2201). Message text is preserved or made more actionable; no logic changes. Build green.

| Site | Was | Now |
|---|---|---|
| `Hook.TargetMethodNotFound()` | `Exception` | `NotSupportedException` - the game binary's Unity/IL2CPP version is unsupported |
| `UnityVersionHandler.GetHandler<T>()` | `ApplicationException` (deprecated since .NET 2.0) | `InvalidOperationException`, now naming the type + Unity version |
| `Class_GetFieldDefaultValue_Hook` | `Exception` | `NotSupportedException` - MonoField absent from `Il2Cppmscorlib.dll` on Unity 2021.2+ |
| `ClassInjector` vtable-slot failure | `Exception` | `InvalidOperationException`, now naming the slot + injected type |
| `ClassInjector.SystemTypeFromIl2CppType` | `NullReferenceException` (a type-lookup failure, not a null deref) | `TypeLoadException` - the canonical type for a failed managed type resolution |

Each is a single-line change on an already-failing error path; none is caught by type elsewhere in the repo (so no catch logic regresses).