### PR TITLE
Various fixes for issues with some Illgames games

### DIFF
--- a/Il2CppInterop.Generator/Extensions/ILGeneratorEx.cs
+++ b/Il2CppInterop.Generator/Extensions/ILGeneratorEx.cs
@@ -172,7 +172,9 @@ public static class ILGeneratorEx
                 body.AddLoadArgument(argumentIndex);
                 body.Add(OpCodes.Ldind_Ref);
                 body.Add(OpCodes.Call, imports.IL2CPP_Il2CppObjectBaseToPtrNotNull.Value);
-                body.Add(OpCodes.Call, imports.IL2CPP_il2cpp_object_unbox.Value);
+
+                if (unboxNonBlittableType)
+                    body.Add(OpCodes.Call, imports.IL2CPP_il2cpp_object_unbox.Value);
             }
             else
             {

--- a/Il2CppInterop.Generator/Passes/Pass50GenerateMethods.cs
+++ b/Il2CppInterop.Generator/Passes/Pass50GenerateMethods.cs
@@ -120,9 +120,10 @@ public static class Pass50GenerateMethods
                         }
 
                         var newParam = newMethod.Parameters[i];
+                        // TODO: create a default instance for Il2CppSystem.ValueType wrapped value type
                         // NOTE(Kas): out parameters of value type are passed directly as a pointer to the il2cpp method
                         // since we don't need to perform any additional copies
-                        if (newParam.Definition!.IsOut && !newParam.ParameterType.GetElementType().IsValueType())
+                        if (newParam.Definition!.IsOut && newParam.ParameterType is ByReferenceTypeSignature && !newParam.ParameterType.GetElementType().IsValueType())
                         {
                             var elementType = newParam.ParameterType.GetElementType();
 

--- a/Il2CppInterop.HarmonySupport/Il2CppDetourMethodPatcher.cs
+++ b/Il2CppInterop.HarmonySupport/Il2CppDetourMethodPatcher.cs
@@ -459,8 +459,12 @@ internal unsafe class Il2CppDetourMethodPatcher : MethodPatcher
 
         if (managedParamType.IsByRef)
         {
-            // TODO: directType being ValueType is not handled yet (but it's not that common in games). Implement when needed.
             var directType = managedParamType.GetElementType();
+            // blittable value type pointer, note that ref to boxed Il2CppSystem.ValueType wrapper is still not handled
+            if (directType.IsValueType)
+                return;
+
+            // TODO: directType being Il2CppSystem.ValueType is not handled yet (but it's not that common in games). Implement when needed.
 
             variable = il.DeclareLocal(directType);
 

--- a/Il2CppInterop.HarmonySupport/Il2CppDetourMethodPatcher.cs
+++ b/Il2CppInterop.HarmonySupport/Il2CppDetourMethodPatcher.cs
@@ -12,11 +12,9 @@ using Il2CppInterop.Runtime.Runtime.VersionSpecific.MethodInfo;
 using Il2CppInterop.Runtime.Startup;
 using Microsoft.Extensions.Logging;
 using MonoMod.Cil;
-using MonoMod.RuntimeDetour;
 using MonoMod.Utils;
-using Detour = MonoMod.RuntimeDetour.Detour;
-using IDetour = Il2CppInterop.Runtime.Injection.IDetour;
 using ValueType = Il2CppSystem.ValueType;
+using Void = Il2CppSystem.Void;
 
 namespace Il2CppInterop.HarmonySupport;
 
@@ -59,8 +57,6 @@ internal unsafe class Il2CppDetourMethodPatcher : MethodPatcher
     };
 
     private static readonly List<object> DelegateCache = new();
-    private static readonly List<object> DetourCache = new();
-
     private INativeMethodInfoStruct modifiedNativeMethodInfo;
 
     private IDetour nativeDetour;
@@ -151,10 +147,8 @@ internal unsafe class Il2CppDetourMethodPatcher : MethodPatcher
         nativeDetour.Apply();
         modifiedNativeMethodInfo.MethodPointer = nativeDetour.OriginalTrampoline;
 
-        var detour = new Detour(Original, managedHookedMethod);
-        detour.Apply();
-        DetourCache.Add(detour);
-
+        // TODO: Add an ILHook for the original unhollowed method to go directly to managedHookedMethod
+        // Right now it goes through three times as much interop conversion as it needs to, when being called from managed side
         return managedHookedMethod;
     }
 

--- a/Il2CppInterop.Runtime/Injection/Hooks/Class_GetFieldDefaultValue_Hook.cs
+++ b/Il2CppInterop.Runtime/Injection/Hooks/Class_GetFieldDefaultValue_Hook.cs
@@ -42,7 +42,6 @@ namespace Il2CppInterop.Runtime.Injection.Hooks
                 mask = "xxxxxxxxxxxxxx?xxxxxxxxxxxxx",
                 xref = false
             },
-
             // V Rising - Unity 2022.3.23 (x64)
             new MemoryUtils.SignatureDefinition
             {
@@ -51,10 +50,12 @@ namespace Il2CppInterop.Runtime.Injection.Hooks
                 xref = false
             },
             // GTFO - Unity 2019.4.21 (x64)
+            // DigitalCraft Dolce 3.1.2 - Unity 2022.3.55 (x64)
             new MemoryUtils.SignatureDefinition
             {
                 pattern = "\x48\x89\x5C\x24\x08\x57\x48\x83\xEC\x20\x48\x8B\x41\x10\x48\x8B\xD9\x48\x8B",
-                mask = "xxxxxxxxxxxxxxxxxxx",
+                // mask the stack allocation length
+                mask = "xxxxxxxxx?xxxxxxxxx",
                 xref = false
             },
             // Idle Slayer - Unity 2021.3.17 (x64)


### PR DESCRIPTION
Battle-tested fixes on various stripped IL2CPP games. Already discussed on discord, got an approval to go ahead and merge.

----

This reverts commit 769f080.

The patch breaks the managed method body when CopyOriginal called on
detoured Original method body, as CopyOriginal expect to operate on
unmodified Original method body.

This essentially breaks applying more than one Harmony patches on a same
hooking target.

----

I'm starting the PR because @y0soro stated [here](https://github.com/y0soro/Il2CppInterop/releases/tag/release-illgames-fixes) that he wouldn't make one and that it is fine to merge his commits as long as they are properly credited.