### PR TITLE
Handle type references that cannot be resolved from the input assemblies

### DIFF
--- a/Il2CppInterop.Generator/Contexts/AssemblyRewriteContext.cs
+++ b/Il2CppInterop.Generator/Contexts/AssemblyRewriteContext.cs
@@ -131,11 +131,48 @@ public class AssemblyRewriteContext
             return sourceModule.DefaultImporter.ImportType(GlobalContext.GetAssemblyByName("mscorlib")
                 .GetTypeByName("System.Attribute").NewType).ToTypeSignature();
 
-        var originalTypeDef = typeRef.Resolve()!;
+        // Cpp2IL's dump can omit a type that another dumped assembly still
+        // references. Observed with the nested enum UnityEngine.Camera.GateFitMode,
+        // which Cinemachine references but which is absent from the dumped
+        // UnityEngine.CoreModule. Such a reference is genuinely unresolvable, so
+        // report it instead of dereferencing null and aborting generation with a
+        // bare NullReferenceException.
+        var originalTypeDef = typeRef.Resolve();
+        if (originalTypeDef == null)
+            throw new UnresolvedTypeReferenceException(typeRef);
+
         var targetAssembly = GlobalContext.GetNewAssemblyForOriginal(originalTypeDef.DeclaringModule!.Assembly!);
         var target = targetAssembly.GetContextForOriginalType(originalTypeDef).NewType;
 
         return sourceModule.DefaultImporter.ImportType(target).ToTypeSignature();
+    }
+
+    /// <summary>
+    /// As <see cref="RewriteTypeRef" />, but returns null when the reference cannot
+    /// be resolved from the input assemblies rather than throwing. Callers can then
+    /// skip whatever they were generating for that reference.
+    /// </summary>
+    public TypeSignature? TryRewriteTypeRef(TypeSignature typeRef)
+    {
+        try
+        {
+            return RewriteTypeRef(typeRef);
+        }
+        catch (UnresolvedTypeReferenceException)
+        {
+            return null;
+        }
+    }
+
+    public sealed class UnresolvedTypeReferenceException : System.Exception
+    {
+        public UnresolvedTypeReferenceException(TypeSignature typeRef)
+            : base($"Could not resolve type reference '{typeRef.FullName}' from the input assemblies.")
+        {
+            TypeReference = typeRef;
+        }
+
+        public TypeSignature TypeReference { get; }
     }
 
     public TypeRewriteContext GetTypeByName(string name)

--- a/Il2CppInterop.Generator/Passes/Pass11ComputeTypeSpecifics.cs
+++ b/Il2CppInterop.Generator/Passes/Pass11ComputeTypeSpecifics.cs
@@ -1,6 +1,8 @@
 using AsmResolver.DotNet.Signatures;
+using Il2CppInterop.Common;
 using Il2CppInterop.Generator.Contexts;
 using Il2CppInterop.Generator.Extensions;
+using Microsoft.Extensions.Logging;
 
 namespace Il2CppInterop.Generator.Passes;
 
@@ -39,7 +41,35 @@ public static class Pass11ComputeTypeSpecifics
                 return;
             }
 
-            var fieldTypeContext = typeContext.AssemblyContext.GlobalContext.GetNewTypeForOriginal(fieldType.Resolve()!);
+            // A field's type is not always resolvable, and even when it is, it
+            // may belong to an assembly that is not part of this rewrite (for
+            // example a type Cpp2IL referenced but did not emit). Both cases
+            // previously produced a null context that was dereferenced on the
+            // recursive call. Treat either as non-blittable, which is the safe
+            // direction: it only costs the slower marshalling path, whereas
+            // wrongly reporting blittable would corrupt memory at runtime.
+            var resolvedFieldType = fieldType.Resolve();
+            if (resolvedFieldType == null)
+            {
+                Logger.Instance.LogTrace(
+                    "Field {FieldType} {TypeName}.{FieldName} could not be resolved; treating the declaring type as non-blittable",
+                    fieldType.FullName, typeContext.OriginalType.FullName, originalField.Name?.ToString());
+
+                typeContext.ComputedTypeSpecifics = TypeRewriteContext.TypeSpecifics.NonBlittableStruct;
+                return;
+            }
+
+            var fieldTypeContext = typeContext.AssemblyContext.GlobalContext.TryGetNewTypeForOriginal(resolvedFieldType);
+            if (fieldTypeContext == null)
+            {
+                Logger.Instance.LogTrace(
+                    "Field type {FieldType} of {TypeName}.{FieldName} is not part of this rewrite; treating the declaring type as non-blittable",
+                    resolvedFieldType.FullName, typeContext.OriginalType.FullName, originalField.Name?.ToString());
+
+                typeContext.ComputedTypeSpecifics = TypeRewriteContext.TypeSpecifics.NonBlittableStruct;
+                return;
+            }
+
             ComputeSpecifics(fieldTypeContext);
             if (fieldTypeContext.ComputedTypeSpecifics != TypeRewriteContext.TypeSpecifics.BlittableStruct)
             {

--- a/Il2CppInterop.Generator/Passes/Pass40GenerateFieldAccessors.cs
+++ b/Il2CppInterop.Generator/Passes/Pass40GenerateFieldAccessors.cs
@@ -1,8 +1,10 @@
 using AsmResolver.DotNet;
 using AsmResolver.DotNet.Signatures;
 using AsmResolver.PE.DotNet.Metadata.Tables;
+using Il2CppInterop.Common;
 using Il2CppInterop.Generator.Contexts;
 using Il2CppInterop.Generator.Utils;
+using Microsoft.Extensions.Logging;
 
 namespace Il2CppInterop.Generator.Passes;
 
@@ -22,7 +24,23 @@ public static class Pass40GenerateFieldAccessors
                     var field = fieldContext.OriginalField;
                     var unmangleFieldName = fieldContext.UnmangledName;
 
-                    var propertyType = assemblyContext.RewriteTypeRef(fieldContext.OriginalField.Signature!.FieldType);
+                    // Skip the accessor when the field's type cannot be resolved
+                    // from the input assemblies. Substituting a placeholder type
+                    // would risk a wrong-sized accessor reading the wrong memory,
+                    // so leaving the field inaccessible is the safe outcome.
+                    var propertyType =
+                        assemblyContext.TryRewriteTypeRef(fieldContext.OriginalField.Signature!.FieldType);
+
+                    if (propertyType == null)
+                    {
+                        Logger.Instance.LogWarning(
+                            "Skipped accessor for {TypeName}.{FieldName}: its type {FieldType} could not be resolved from the input assemblies, so the field will be inaccessible",
+                            typeContext.OriginalType.FullName, field.Name?.ToString(),
+                            fieldContext.OriginalField.Signature!.FieldType.FullName);
+
+                        continue;
+                    }
+
                     var signature = field.IsStatic
                         ? PropertySignature.CreateStatic(propertyType)
                         : PropertySignature.CreateInstance(propertyType);


### PR DESCRIPTION
## Problem

Interop assembly generation aborts with a bare `NullReferenceException` when the Cpp2IL dump contains a type reference that cannot be resolved from the input assemblies:

```
[ERROR] Error Generating Interop Assemblies!
System.NullReferenceException: Object reference not set to an instance of an object.
   at Il2CppInterop.Generator.Passes.Pass11ComputeTypeSpecifics.ComputeSpecifics(TypeRewriteContext typeContext) in Pass11ComputeTypeSpecifics.cs:line 18
   at Il2CppInterop.Generator.Passes.Pass11ComputeTypeSpecifics.ComputeSpecifics(TypeRewriteContext typeContext) in Pass11ComputeTypeSpecifics.cs:line 18
   at Il2CppInterop.Generator.Passes.Pass11ComputeTypeSpecifics.DoPass(RewriteGlobalContext context) in Pass11ComputeTypeSpecifics.cs:line 12
```

Because generation fails outright, no mod can load at all.

## Root cause

Cpp2IL's dump of `UnityEngine.CoreModule.dll` omits the nested enum `UnityEngine.Camera.GateFitMode`, while the dumped `Cinemachine.dll` still declares a field of that type (`Cinemachine.LensSettings.GateFit`). The reference is therefore genuinely unresolvable from the dump, and `typeRef.Resolve()` returns `null`.

Two places assume resolution always succeeds and suppress the nullability with `!`:

1. **`Pass11ComputeTypeSpecifics.ComputeSpecifics`** — passes the resulting `null` context straight into its own recursive call, which dereferences it on entry. This is the crash above.
2. **`AssemblyRewriteContext.RewriteTypeRef`** — dereferences `originalTypeDef.DeclaringModule`. Reached from `Pass40GenerateFieldAccessors`, and only surfaces once the first site is fixed.

This is not specific to one game: any title whose dump omits a type that another dumped assembly references will hit it. It was found on Schedule I (Unity 2022.3.62f2, IL2CPP metadata 31.1) after a game update, where it broke every mod for every player.

## Changes

**`Pass11ComputeTypeSpecifics`** — treat an unresolvable field type, or one whose type is not part of the rewrite, as **non-blittable**.

This direction is deliberate. Non-blittable only costs the slower marshalling path, whereas incorrectly reporting a type as blittable would produce wrong struct layouts and corrupt memory at runtime. `RewriteGlobalContext.TryGetNewTypeForOriginal` already existed for the second case and is now used instead of the throwing indexer.

**`AssemblyRewriteContext`** — `RewriteTypeRef` now throws a descriptive `UnresolvedTypeReferenceException` instead of dereferencing `null`, and a new `TryRewriteTypeRef` returns `null` for that case so callers can skip what they were generating.

**`Pass40GenerateFieldAccessors`** — skips the accessor when the field's type cannot be rewritten, logging a warning naming the type and field.

Substituting a placeholder type here was considered and rejected: the omitted type in the observed case is a 4-byte enum, and a wrong-sized accessor would read the wrong memory. Leaving the field inaccessible is the safe outcome, and the warning makes it visible.

## Reproduction

Against a dump exhibiting the omission:

```
Il2CppInterop.CLI generate --input <cpp2il_out> --output <out> --unity <UnityDependencies> --game-assembly GameAssembly.dll
```

Before: `NullReferenceException` in `Pass11ComputeTypeSpecifics`, no assemblies produced.
After: generation completes, 148 assemblies written, with one warning:

```
warn: Skipped accessor for Cinemachine.LensSettings.GateFit: its type UnityEngine.Camera+GateFitMode
      could not be resolved from the input assemblies, so the field will be inaccessible
```

## Testing

- Verified via `Il2CppInterop.CLI` that generation completes end to end and writes all assemblies.
- Loaded the resulting assemblies in-game under MelonLoader 0.7.3 (which bundles this version): assembly generation reports success and all mods load and run, including mods using Harmony patches and reflection over game types.
- Exactly one field across the entire game was affected, in a Unity package rather than game code.
