### PR TITLE
Fix GC reference tracking for injected classes

### DIFF
--- a/Il2CppInterop.Runtime/IL2CPP.cs
+++ b/Il2CppInterop.Runtime/IL2CPP.cs
@@ -369,6 +369,27 @@ public static unsafe class IL2CPP
         *(IntPtr*)targetAddress = value;
     }
 
+    private static volatile bool s_fieldWriteWbarrierAvailable = true;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void FieldWriteWbarrier(IntPtr obj, IntPtr targetAddress, IntPtr value)
+    {
+        if (s_fieldWriteWbarrierAvailable)
+        {
+            try
+            {
+                il2cpp_gc_wbarrier_set_field(obj, targetAddress, value);
+                return;
+            }
+            catch (EntryPointNotFoundException)
+            {
+                s_fieldWriteWbarrierAvailable = false;
+            }
+        }
+
+        FieldWriteWbarrierStub(obj, targetAddress, value);
+    }
+
     // IL2CPP Functions
     [DllImport("GameAssembly", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
     public static extern void il2cpp_init(IntPtr domain_name);

--- a/Il2CppInterop.Runtime/Injection/ClassInjector.cs
+++ b/Il2CppInterop.Runtime/Injection/ClassInjector.cs
@@ -250,6 +250,7 @@ public static unsafe partial class ClassInjector
             .Where(IsFieldEligible)
             .ToArray();
         classPointer.FieldCount = (ushort)fieldsToInject.Length;
+        classPointer.HasReferences = baseClassPointer.HasReferences;
 
         var il2cppFields =
             (Il2CppFieldInfo*)Marshal.AllocHGlobal(classPointer.FieldCount * UnityVersionHandler.FieldInfoSize());
@@ -266,6 +267,9 @@ public static unsafe partial class ClassInjector
                 : fieldsToInject[i].FieldType.GenericTypeArguments[0];
             var fieldAttributes = fieldsToInject[i].Attributes;
             var fieldInfoClass = Il2CppClassPointerStore.GetNativeClassPointer(fieldType);
+            if (fieldInfoClass == IntPtr.Zero)
+                throw new Exception($"Type {fieldType} in {type}.{fieldsToInject[i].Name} doesn't exist in Il2Cpp");
+
             if (!_injectedFieldTypes.TryGetValue((fieldType, fieldAttributes), out var fieldTypePtr))
             {
                 var classType =
@@ -283,10 +287,11 @@ public static unsafe partial class ClassInjector
             }
 
             fieldInfo.Type = (Il2CppTypeStruct*)fieldTypePtr;
-            if (fieldInfoClass == IntPtr.Zero)
-                throw new Exception($"Type {fieldType} in {type}.{fieldsToInject[i].Name} doesn't exist in Il2Cpp");
+            var fieldIsValueType = IL2CPP.il2cpp_class_is_valuetype(fieldInfoClass);
+            classPointer.HasReferences |= !fieldIsValueType ||
+                                          IL2CPP.il2cpp_class_has_references(fieldInfoClass);
 
-            if (IL2CPP.il2cpp_class_is_valuetype(fieldInfoClass))
+            if (fieldIsValueType)
             {
                 uint _align = 0;
                 var fieldSize = IL2CPP.il2cpp_class_value_size(fieldInfoClass, ref _align);

--- a/Il2CppInterop.Runtime/InteropTypes/Fields/Il2CppReferenceField.cs
+++ b/Il2CppInterop.Runtime/InteropTypes/Fields/Il2CppReferenceField.cs
@@ -28,7 +28,9 @@ public unsafe class Il2CppReferenceField<TRefObj> where TRefObj : Il2CppObjectBa
 
     public void Set(TRefObj value)
     {
-        *GetPointerToData() = value != null ? value.Pointer : IntPtr.Zero;
+        var targetAddress = (IntPtr)GetPointerToData();
+        IL2CPP.FieldWriteWbarrier(_obj.Pointer, targetAddress,
+            value != null ? value.Pointer : IntPtr.Zero);
     }
 
     public static implicit operator TRefObj(Il2CppReferenceField<TRefObj> _this)

--- a/Il2CppInterop.Runtime/InteropTypes/Fields/Il2CppStringField.cs
+++ b/Il2CppInterop.Runtime/InteropTypes/Fields/Il2CppStringField.cs
@@ -30,7 +30,9 @@ public unsafe class Il2CppStringField
 
     public void Set(string value)
     {
-        *GetPointerToData() = IL2CPP.ManagedStringToIl2Cpp(value);
+        var targetAddress = (IntPtr)GetPointerToData();
+        IL2CPP.FieldWriteWbarrier(_obj.Pointer, targetAddress,
+            IL2CPP.ManagedStringToIl2Cpp(value));
     }
 
     public static implicit operator string(Il2CppStringField _this)

--- a/Il2CppInterop.Runtime/Runtime/VersionSpecific/Class/Interfaces.cs
+++ b/Il2CppInterop.Runtime/Runtime/VersionSpecific/Class/Interfaces.cs
@@ -31,6 +31,11 @@ public interface INativeClassStruct : INativeStruct
     bool Initialized { get; set; }
     bool InitializedAndNoError { get; set; }
     bool SizeInited { get; set; }
+    bool HasReferences
+    {
+        get => false;
+        set { }
+    }
     bool HasFinalize { get; set; }
     bool IsVtableInitialized { get; set; }
 


### PR DESCRIPTION
## Problem

`ClassInjector` does not propagate the base class's `has_references` flag or update it when adding reference-containing fields to an injected class.

In addition, `Il2CppReferenceField.Set()` and `Il2CppStringField.Set()` write object pointers directly:

```csharp
*GetPointerToData() = value;
```

This bypasses IL2CPP's GC write barrier. Together, the incorrect class metadata and raw reference writes can cause the collector or Unity liveness processing to miss objects reachable through injected fields. Those objects may then be reclaimed while still referenced, resulting in intermittent native access violations.

This is mostly relevant for injected types that inherit from base classes containing references.

## Change

- Propagate `has_references` from the injected class's base class.
- Set `has_references` when an injected field is:
  - a reference type; or
  - a value type that itself contains references.
- Use `il2cpp_gc_wbarrier_set_field` when assigning injected reference and string fields.
- Fall back to the existing raw pointer write when the native write-barrier export is unavailable.
- Expose `HasReferences` through `INativeClassStruct`.
- Validate the native field class pointer before querying its metadata.

Classes without references retain their previous metadata and layout. Unity versions without the write-barrier export retain the previous field-write behavior through the fallback, so existing setups remain unaffected.