### PR TITLE
Add Class::Init signature for Unity 2022.3 x64

### DIFF
--- a/Il2CppInterop.Runtime/Injection/InjectorHelpers.cs
+++ b/Il2CppInterop.Runtime/Injection/InjectorHelpers.cs
@@ -150,6 +150,13 @@ namespace Il2CppInterop.Runtime.Injection
         {
             new MemoryUtils.SignatureDefinition
             {
+                // Unity 2022.3 x64 - call to Class::Init from il2cpp_class_has_references
+                pattern = "\xE8\x00\x00\x00\x00\xF6\x83\x36\x01\x00\x00\x01\x74\x00\x0F\xB6\x83\x35\x01\x00\x00",
+                mask = "x????xxxxxxxx?xxxxxxx",
+                xref = true
+            },
+            new MemoryUtils.SignatureDefinition
+            {
                 pattern = "\xE8\x00\x00\x00\x00\x0F\xB7\x47\x28\x83",
                 mask = "x????xxxxx",
                 xref = true


### PR DESCRIPTION
Games built with Unity 2022.3 (x64, MSVC) fall through the existing s_ClassInitSignatures entries and hit the substitute path. This adds a signature that resolves Class::Init correctly on that generation.

Derived from the call to Class::Init inside il2cpp_class_has_references, an exported function present in every il2cpp build. The trailing bytes are that export's own re-check of the initialized flag:

```
E8 ?? ?? ?? ??           call Class::Init
F6 83 36 01 00 00 01     test [rbx+136h], 1     ; klass->initialized
74 ??                    jz
0F B6 83 35 01 00 00     movzx eax, [rbx+135h]
```

Verified unique within the module, and confirmed at runtime to resolve to the same address identified statically in Ghidra.

Caveat: the F6 83 / 0F B6 83 encodings pin RBX as the base register. Builds that allocate a different register there won't match, so this may not cover every 2022.3 game.

Tested on Unity 2022.3.62f3 (ZERO PARADES For Dead Spies), Il2CppInterop v1.5.3, BepInEx 6.0.0-be.785.

Before: `Class::Init signatures have been exhausted, using a substitute!`
After: `Class::Init: 0x...` resolving correctly, with plugins loading normally.